### PR TITLE
overload NXP build_quant_pipeline

### DIFF
--- a/ppq/quantization/quantizer/NXPQuantizer.py
+++ b/ppq/quantization/quantizer/NXPQuantizer.py
@@ -28,7 +28,7 @@ class NXP_Quantizer(BaseQuantizer):
 
         super().__init__(graph=graph)
 
-    def create_optim_pipeline_from_setting(
+    def build_quant_pipeline(
         self, setting: QuantizationSetting, executor: BaseGraphExecutor) -> QuantizationOptimizationPipeline:
         pipeline = super().build_quant_pipeline(setting, executor)
         pipeline.append_optimization_to_pipeline(NXPResizeModeChangePass(), at_front=True)


### PR DESCRIPTION
overload `build_quant_pipeline` for `NXP_Quantizer`. `create_optim_pipeline_from_setting` doesn't have any reference in codebase. 