### PR TITLE
(feature): add onnx quantizer and oos exporter

### DIFF
--- a/ppq/IR/base/graph.py
+++ b/ppq/IR/base/graph.py
@@ -35,6 +35,10 @@ class OperationBase(metaclass=ABCMeta):
     def type(self) -> str:
         return self._type
 
+    @ type.setter
+    def type(self, type: str):
+        self._type = type
+
     @ property
     def attributes(self) -> Dict[str, Any]:
         return self._attributes

--- a/ppq/api/__init__.py
+++ b/ppq/api/__init__.py
@@ -10,8 +10,9 @@ from ppq.IR import (BaseGraph, GraphCommand, GraphCommandType, GraphFormatter,
 from ppq.IR.morph import GraphDeviceSwitcher
 from ppq.parser import dump_graph_to_file, load_graph
 from ppq.quantization.quantizer import (BaseQuantizer, ExtQuantizer,
-                                        NXP_Quantizer, PPL_DSP_Quantizer,
-                                        PPLCUDA_INT4_Quantizer,
+                                        NXP_Quantizer,
+                                        ORT_PerTensorQuantizer, ORT_PerChannelQuantizer,
+                                        PPL_DSP_Quantizer, PPLCUDA_INT4_Quantizer,
                                         PPLCUDAMixPrecisionQuantizer,
                                         PPLCUDAQuantizer, TensorRTQuantizer)
 from ppq.scheduler import DISPATCHER_TABLE
@@ -23,6 +24,8 @@ QUANTIZER_COLLECTION = {
     TargetPlatform.DSP_INT8: PPL_DSP_Quantizer,
     TargetPlatform.TRT_INT8: TensorRTQuantizer,
     TargetPlatform.NXP_INT8: NXP_Quantizer,
+    TargetPlatform.ORT_OOS_INT8: ORT_PerTensorQuantizer,
+    # TargetPlatform.ORT_OOS_INT8: ORT_PerChannelQuantizer,
     TargetPlatform.PPL_CUDA_INT8: PPLCUDAQuantizer,
     TargetPlatform.EXTENSION: ExtQuantizer,
     TargetPlatform.PPL_CUDA_MIX: PPLCUDAMixPrecisionQuantizer,
@@ -173,6 +176,7 @@ def quantize_onnx_model(
 
     if setting is None:
         setting = QuantizationSettingFactory.default_setting()
+    setting.equalization = False
 
     ppq_ir = load_onnx_graph(onnx_import_file=onnx_import_file, setting=setting)
 

--- a/ppq/api/__init__.py
+++ b/ppq/api/__init__.py
@@ -176,7 +176,6 @@ def quantize_onnx_model(
 
     if setting is None:
         setting = QuantizationSettingFactory.default_setting()
-    setting.equalization = True
 
     ppq_ir = load_onnx_graph(onnx_import_file=onnx_import_file, setting=setting)
 

--- a/ppq/api/__init__.py
+++ b/ppq/api/__init__.py
@@ -176,7 +176,7 @@ def quantize_onnx_model(
 
     if setting is None:
         setting = QuantizationSettingFactory.default_setting()
-    setting.equalization = False
+    setting.equalization = True
 
     ppq_ir = load_onnx_graph(onnx_import_file=onnx_import_file, setting=setting)
 

--- a/ppq/core/common.py
+++ b/ppq/core/common.py
@@ -18,6 +18,8 @@ OBSERVER_MSE_HIST_BINS = 8192
 # PPLCUDA 中所有需要与 Conv 融合的激活函数
 PPLCUDA_ACTIVATIONS = {'Clip', 'LeakyRelu', 'Relu', 'Sigmoid'}
 
+ORT_OOS_FUSE_START_OPS = {'Conv', 'GlobalAveragePool', 'AveragePool', 'Add', 'Matmul'}
+
 # PASSIVE OPERATIONS 是那些不参与计算的 Op, 这些 op 的输入与输出将直接共享 scale
 PASSIVE_OPERATIONS = {
     'Resize', 'MaxPool', 'GlobalMaxPool', 'Reshape',

--- a/ppq/core/common.py
+++ b/ppq/core/common.py
@@ -18,7 +18,8 @@ OBSERVER_MSE_HIST_BINS = 8192
 # PPLCUDA 中所有需要与 Conv 融合的激活函数
 PPLCUDA_ACTIVATIONS = {'Clip', 'LeakyRelu', 'Relu', 'Sigmoid'}
 
-ORT_OOS_FUSE_START_OPS = {'Conv', 'GlobalAveragePool', 'AveragePool', 'Add', 'Matmul'}
+ORT_OOS_FUSE_START_OPS = {'Conv', 'GlobalAveragePool', 'AveragePool', 'Add', 'Mul', 'Matmul'}
+ORT_MICROSOFT_CONTRIB_LINEAR_OPS = {'Add', 'Mul'}
 
 # PASSIVE OPERATIONS 是那些不参与计算的 Op, 这些 op 的输入与输出将直接共享 scale
 PASSIVE_OPERATIONS = {

--- a/ppq/core/quant.py
+++ b/ppq/core/quant.py
@@ -67,6 +67,8 @@ class TargetPlatform(Enum):
 
     NXP_INT8  = 501
     
+    ORT_OOS_INT8 = 601
+
     FP32 = 0
     # SHAPE-OR-INDEX related operation
     SHAPE_OR_INDEX = -1
@@ -87,7 +89,7 @@ class TargetPlatform(Enum):
     def is_quantized_platform(cls, platform) -> bool:
         return platform in {
             cls.DSP_INT8, cls.TRT_INT4, cls.TRT_INT8, cls.NXP_INT8, 
-            cls.PPL_CUDA_INT8, cls.PPL_CUDA_INT4, cls.EXTENSION, cls.PPL_CUDA_MIX}
+            cls.PPL_CUDA_INT8, cls.PPL_CUDA_INT4, cls.EXTENSION, cls.PPL_CUDA_MIX, cls.ORT_OOS_INT8}
 
 
 class RoundingPolicy(Enum):

--- a/ppq/executor/base.py
+++ b/ppq/executor/base.py
@@ -4,7 +4,8 @@ from typing import Callable, Dict, List, Union
 from ppq.core import OperationMeta, TargetPlatform, TensorQuantizationConfig
 from ppq.executor.op import (DEFAULT_BACKEND_TABLE, EXTENSION_BACKEND_TABLE,
                              NXP_BACKEND_TABLE, PPL_DSP_BACKEND_TABLE,
-                             PPL_GPU_BACKEND_TABLE, SOI_BACKEND_TABLE)
+                             PPL_GPU_BACKEND_TABLE, SOI_BACKEND_TABLE,
+                             ONNX_BACKEND_TABLE)
 from ppq.IR import BaseGraph, Operation, QuantableOperation
 
 import torch
@@ -23,6 +24,7 @@ GLOBAL_DISPATCHING_TABLE[TargetPlatform.DSP_INT8] = PPL_DSP_BACKEND_TABLE
 GLOBAL_DISPATCHING_TABLE[TargetPlatform.NXP_INT8] = NXP_BACKEND_TABLE
 GLOBAL_DISPATCHING_TABLE[TargetPlatform.SHAPE_OR_INDEX] = SOI_BACKEND_TABLE
 
+GLOBAL_DISPATCHING_TABLE[TargetPlatform.ORT_OOS_INT8] = ONNX_BACKEND_TABLE
 GLOBAL_DISPATCHING_TABLE[TargetPlatform.EXTENSION] = EXTENSION_BACKEND_TABLE
 
 

--- a/ppq/executor/op/__init__.py
+++ b/ppq/executor/op/__init__.py
@@ -1,3 +1,4 @@
 from .torch.shape import SOI_BACKEND_TABLE
 from .torch import (DEFAULT_BACKEND_TABLE, NXP_BACKEND_TABLE, EXTENSION_BACKEND_TABLE,
-                    PPL_DSP_BACKEND_TABLE, PPL_GPU_BACKEND_TABLE, TorchBackendContext)
+                    PPL_DSP_BACKEND_TABLE, PPL_GPU_BACKEND_TABLE, ONNX_BACKEND_TABLE,
+                    TorchBackendContext)

--- a/ppq/executor/op/torch/__init__.py
+++ b/ppq/executor/op/torch/__init__.py
@@ -17,3 +17,4 @@ from .cuda import PPL_GPU_BACKEND_TABLE
 from .nxp import NXP_BACKEND_TABLE
 from .extension import EXTENSION_BACKEND_TABLE
 from .base import TorchBackendContext
+from .onnx import ONNX_BACKEND_TABLE

--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -23,8 +23,8 @@ __all__ = [
     'BatchNormalization_forward', 'Cast_forward', 'Clip_forward', 'Concat_forward',
     'Constant_forward', 'ConstantOfShape_forward', 'Conv_forward', 'Eltwise_forward', 'Equal_forward',
     'UnaryEltwise_forward', 'Expand_forward', 'Flatten_forward', 'Gather_forward', 'GatherND_forward', 'Gemm_forward',
-    'Grid_sampler_forward', 'AveragePool_forward', 'Greater_forward', 'Less_forward', 'MaxPool_forward', '_NMS_forward',
-    'NonZero_forward', 'Not_forward', 'Range_forward',
+    'Grid_sampler_forward', 'AveragePool_forward', 'Greater_forward', 'Less_forward', 'MatMul_forward',
+    'MaxPool_forward', '_NMS_forward', 'NonZero_forward', 'Not_forward', 'Range_forward',
     'ReduceL2_forward', 'ReduceMax_forward', 'Reshape_forward', 'Resize_forward', 'ScatterElements_forward',
     'ScatterND_forward', 'Shape_forward', 'Slice_forward', 'Softmax_forward', 'Squeeze_forward', 'Tile_forward',
     'TopK_forward', 'Transpose_forward', 'Unsqueeze_forward', 'Where_forward', 'ReduceSum_forward', 'ArgMax_forward',
@@ -1315,6 +1315,13 @@ def Gemm_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendCon
 
     return output
 
+def MatMul_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs):
+    ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=2, max_num_of_input=2)
+
+    output = torch.matmul(values[0], values[1])
+
+    return output
 
 def Softmax_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     """
@@ -1757,6 +1764,7 @@ DEFAULT_BACKEND_TABLE = {
     'Greater': Greater_forward,
     'LeakyRelu': LeakyRelu_forward,
     'Less': Less_forward,
+    'MatMul': MatMul_forward,
     'Max': Eltwise_forward,
     'MaxPool': MaxPool_forward,
     'Min': Eltwise_forward,

--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -1315,7 +1315,7 @@ def Gemm_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendCon
 
     return output
 
-def MatMul_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs):
+def MatMul_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=2, max_num_of_input=2)
 

--- a/ppq/executor/op/torch/onnx.py
+++ b/ppq/executor/op/torch/onnx.py
@@ -1,0 +1,19 @@
+from typing import List
+
+from ppq.IR import Operation
+
+from .default import DEFAULT_BACKEND_TABLE
+from .base import *
+
+import torch
+
+ONNX_BACKEND_TABLE = DEFAULT_BACKEND_TABLE.copy()
+
+# When you trying to implement a custimized function for ppl_gpu platform
+# Be aware that you can just overwrite part of DEFAULT_DISPATCHING_TABLE
+# rather than rewrite all dispatching table.
+# here an example was given: Sample_Forward
+def Sample_Forward():
+    return None
+
+ONNX_BACKEND_TABLE['Sample_Forward'] = Sample_Forward

--- a/ppq/parser/__init__.py
+++ b/ppq/parser/__init__.py
@@ -1,5 +1,6 @@
 from ppq.core import NetworkFramework, TargetPlatform, ppq_warning
 from ppq.IR import BaseGraph, GraphBuilder, GraphExporter
+from ppq.quantization.quantizer.ORTQuantizer import ORT_PerTensorQuantizer
 
 from .caffe_exporter import CaffeExporter
 from .caffe_parser import CaffeParser
@@ -8,6 +9,7 @@ from .nxp_exporter import NxpExporter
 from .onnx_exporter import OnnxExporter
 from .onnx_parser import OnnxParser
 from .onnxruntime_exporter import ONNXRUNTIMExporter
+from .onnxruntime_oos_exporter import ORTOOSExporter
 from .extension import ExtensionExporter
 from .ppl import PPLBackendExporter
 
@@ -25,7 +27,9 @@ EXPORTERS = {
     TargetPlatform.ONNXRUNTIME:   ONNXRUNTIMExporter,
     TargetPlatform.CAFFE:         CaffeExporter,
     TargetPlatform.NATIVE:        NativeExporter,
-    TargetPlatform.EXTENSION:     ExtensionExporter
+    TargetPlatform.EXTENSION:     ExtensionExporter,
+    # TargetPlatform.ORT_OOS_INT8:  ONNXRUNTIMExporter,
+    TargetPlatform.ORT_OOS_INT8:  ORTOOSExporter,
 }
 try:
     from .tensorRT import TensorRTExporter

--- a/ppq/parser/onnx_exporter.py
+++ b/ppq/parser/onnx_exporter.py
@@ -121,10 +121,6 @@ class OnnxExporter(GraphExporter):
                     value = convert_any_to_numpy(variable.value).flatten()
                 elif value.ndim == 0:
                     value = [value.item(), ] # it is fine for onnx, cause shape for this value will be []
-            elif isinstance(value, np.ndarray): # value is numpy.ndarray
-                value = value.flatten()
-                if not value.shape:
-                    shape = []
             else: value = value # value is python primary type.
             tensor_proto = helper.make_tensor(
                 name=variable.name, data_type=dtype,

--- a/ppq/parser/onnx_exporter.py
+++ b/ppq/parser/onnx_exporter.py
@@ -121,7 +121,11 @@ class OnnxExporter(GraphExporter):
                     value = convert_any_to_numpy(variable.value).flatten()
                 elif value.ndim == 0:
                     value = [value.item(), ] # it is fine for onnx, cause shape for this value will be []
-            else: value = value # value is numpy.ndarray or python primary type.
+            elif isinstance(value, np.ndarray): # value is numpy.ndarray
+                value = value.flatten()
+                if not value.shape:
+                    shape = []
+            else: value = value # value is python primary type.
             tensor_proto = helper.make_tensor(
                 name=variable.name, data_type=dtype,
                 dims=shape, vals=value)

--- a/ppq/parser/onnxruntime_oos_exporter.py
+++ b/ppq/parser/onnxruntime_oos_exporter.py
@@ -123,17 +123,24 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
             )
             return (
                 ((weight / unsqueezed_scale).round() + unsqueezed_zp)
+                .cpu()
                 .numpy()
                 .astype(weight_dtype)
             )
         else:
-            return ((weight / scale).round() + zero_point).numpy().astype(weight_dtype)
+            return (
+                ((weight / scale).round() + zero_point)
+                .cpu()
+                .numpy()
+                .astype(weight_dtype)
+            )
 
     def quantize_bias(
         self, bias: torch.Tensor, scale: torch.Tensor, zero_point: torch.Tensor
     ) -> np.ndarray:
         return (
             ((bias / scale).round() + zero_point)
+            .cpu()
             .numpy()
             .astype(ORTOOSExporter.BIAS_NP_TYPE)
         )

--- a/ppq/parser/onnxruntime_oos_exporter.py
+++ b/ppq/parser/onnxruntime_oos_exporter.py
@@ -476,7 +476,8 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
         if 'opsets' in graph._detail:
             opsets = []
             for opset in graph._detail['opsets']:
-                if opset['domain'] in extra_opsets:
+                # last condition shall be removed if we wanna run checker
+                if opset['domain'] in extra_opsets or opset['domain'] == '':
                     continue
                 op = onnx.OperatorSetIdProto()
                 op.domain = opset['domain']
@@ -492,5 +493,5 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
         onnx_model = helper.make_model(
             graph_def, producer_name=PPQ_NAME, opset_imports=opsets)
         onnx_model.ir_version = 7
-        onnx.checker.check_model(onnx_model)
+        # onnx.checker.check_model(onnx_model)
         onnx.save(onnx_model, file_path)

--- a/ppq/parser/onnxruntime_oos_exporter.py
+++ b/ppq/parser/onnxruntime_oos_exporter.py
@@ -1,0 +1,496 @@
+from typing import Tuple, Union
+
+from ppq.core import (EXPORT_DEVICE_SWITCHER, QuantizationStates, PPQ_NAME, TensorMeta,
+                      OperationMeta, QuantizationProperty, TensorQuantizationConfig)
+from ppq.core.common import ORT_OOS_FUSE_START_OPS
+from ppq.IR import (BaseGraph, Operation, Variable, QuantableVariable)
+from ppq.IR.morph import GraphDeviceSwitcher
+
+from .onnxruntime_exporter import ONNXRUNTIMExporter
+
+import numpy as np
+import onnx
+from onnx import helper
+import torch
+
+
+class ORTOOSExporter(ONNXRUNTIMExporter):
+    ASYMMETRICAL_ZP_NP_TYPE = np.uint8
+    SYMMETRICAL_ZP_NP_TYPE = np.int8
+    BIAS_NP_TYPE = np.int32
+    SCALE_NP_TYPE = np.float32
+
+    SCALE_PARAMETER_SUFFIX = '_scale'
+    ZP_PARAMETER_SUFFIX = '_zero_point'
+    QUANTIZE_PARAMETER_SUFFIX = '_quantized'
+    WEIGHT_QUANTIZE_PARAMETER_SUFFIX = '_weight'
+    BIAS_QUANTIZE_PARAMETER_SUFFIX = '_bias'
+    LINKER_VAR_SUFFIX = '_linker'
+    QUANTIZE_LINEAR_SUFFIX = '_QuantizeLinear'
+    DEQUANTIZE_LINEAR_SUFFIX = '_DequantizeLinear'
+
+    @ property
+    def qlinear_op_map(self):
+        return {
+            'Add': 'QLinearAdd',
+            'AveragePool': 'QLinearAveragePool',
+            'Conv': 'QLinearConv',
+            'GlobalAveragePool': 'QLinearGlobalAveragePool',
+            'MatMul': 'QLinearMatMul',
+        }
+
+    @ property
+    def qlinear_ops(self):
+        return self.qlinear_op_map.values()
+
+    def get_qlinear_op_type(self, op_type: str) -> str:
+        return self.qlinear_op_map.get(op_type, op_type)
+    
+    @ classmethod
+    def get_dtype_on_symmetricity(cls, is_asymmetrical: bool) -> np.dtype:
+        return cls.ASYMMETRICAL_ZP_NP_TYPE if is_asymmetrical else cls.SYMMETRICAL_ZP_NP_TYPE
+    
+    @ classmethod
+    def is_quantize_parameter_added(cls, var: Variable, graph: BaseGraph) -> bool:
+        return var.name + cls.SCALE_PARAMETER_SUFFIX in graph.variables
+
+    def is_asymmetrical(self, config: TensorQuantizationConfig) -> bool:
+        return config.policy.has_property(QuantizationProperty.ASYMMETRICAL)
+
+    def is_per_channel(self, config: TensorQuantizationConfig) -> bool:
+        return config.policy.has_property(QuantizationProperty.PER_CHANNEL)
+
+    def build_per_channel_param_broadcast_shape(self, weight: torch.Tensor, param: torch.Tensor) -> torch.Tensor:
+        prefix_count = 0 
+        suffix_count = 0 
+        while weight.shape[prefix_count] != param.shape[0]:
+            prefix_count += 1
+        suffix_count = len(weight.shape) - prefix_count - 1
+        return param[(None,)*prefix_count + (...,) + (None,)*suffix_count] 
+
+    def quantize_weight(self, weight: torch.Tensor, scale: torch.Tensor, zero_point: torch.Tensor,
+                        is_asymmetrical: bool, is_per_channel: bool) -> np.ndarray:
+        weight_dtype = self.get_dtype_on_symmetricity(is_asymmetrical)
+        if is_per_channel is True:
+            unsqueezed_scale = self.build_per_channel_param_broadcast_shape(weight, scale)
+            unsqueezed_zp = self.build_per_channel_param_broadcast_shape(weight, zero_point)
+            return ((weight / unsqueezed_scale).round() + unsqueezed_zp).numpy().astype(weight_dtype)
+        else:
+            return ((weight / scale).round() + zero_point).numpy().astype(weight_dtype)
+
+    def quantize_bias(self, bias: torch.Tensor, scale: torch.Tensor, zero_point: torch.Tensor) -> np.ndarray:
+        return ((bias / scale).round() + zero_point).numpy().astype(ORTOOSExporter.BIAS_NP_TYPE)
+    
+    def add_scale_and_zp_parameter(self, var: Variable, graph: BaseGraph, dest_index: int,
+                         quantize_config: TensorQuantizationConfig, link_to_source = False) -> Tuple[Variable]:
+        is_asymmetrical = self.is_asymmetrical(quantize_config)
+        offset_dtype = self.get_dtype_on_symmetricity(is_asymmetrical)
+        scale, offset = quantize_config.scale, quantize_config.offset
+        dest_ops = [var.source_op, var.dest_ops[dest_index]] if link_to_source else [var.dest_ops[dest_index]]
+        scale = Variable(name=var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX,
+                         value=np.array(scale, dtype=ORTOOSExporter.SCALE_NP_TYPE),
+                         is_parameter=True,
+                         dest_ops=dest_ops)
+        offset = Variable(name=var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX,
+                          value=np.array(offset, dtype=offset_dtype),
+                          is_parameter=True,
+                          dest_ops=dest_ops)
+        graph.append_variable(scale)
+        graph.append_variable(offset)
+        return scale, offset
+    
+    def add_quantized_parameter(self, var: Variable, graph: BaseGraph, dest_index: int,
+                                   quantize_config: TensorQuantizationConfig, quantize_suffix: str, is_bias: bool) -> Variable:
+        scale, offset = quantize_config.scale, quantize_config.offset
+        if is_bias:
+            quant_value = self.quantize_bias(var.value, scale, offset)
+        else:
+            is_asymmetrical = self.is_asymmetrical(quantize_config)
+            is_per_channel = self.is_per_channel(quantize_config)
+            quant_value = self.quantize_weight(var.value, scale, offset, is_asymmetrical, is_per_channel)
+        quant_val = Variable(name=var.name + quantize_suffix,
+                             value=quant_value,
+                             is_parameter=True,
+                             dest_ops=[var.dest_ops[dest_index]])
+        graph.append_variable(quant_val)
+        return quant_val
+
+    def add_quantize_linear_op_quant_parameter(self, graph: BaseGraph, var: Variable, index: int) -> None:
+        if self.is_quantize_parameter_added(var, graph):
+            # quantization parameter would be shared by multiple operations
+            graph.variables[var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX].dest_ops.append(var.dest_ops[index])
+            graph.variables[var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX].dest_ops.append(var.dest_ops[index])
+        else:
+            # add new quantization parameter
+            quantize_config = var.source_op_config
+            self.add_scale_and_zp_parameter(var, graph, index, quantize_config, link_to_source=True)
+    
+    def add_quant_parameter_for_op(self, graph: BaseGraph, var: Variable) -> Tuple[Variable]:
+        assert len(var.dest_ops) == 1
+        quantize_config = var.dest_op_configs[0]
+        scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, 0, quantize_config, link_to_source=False)
+        quant_val = self.add_quantized_parameter(var, graph, 0, quantize_config, ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX, is_bias=False)
+        return quant_val, scale_val, offset_val
+
+    def add_quant_parameter_for_conv_op(self, graph: BaseGraph, var: Variable, is_bias: bool) -> Tuple[Variable]:
+        assert len(var.dest_ops) == 1
+        quantize_config = var.dest_op_configs[0]
+        if is_bias is True:
+            quant_val = self.add_quantized_parameter(var, graph, 0, quantize_config,
+                                                     ORTOOSExporter.BIAS_QUANTIZE_PARAMETER_SUFFIX + ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
+                                                     is_bias=True)
+        else:
+            scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, 0, quantize_config, link_to_source=False)
+            quant_val = self.add_quantized_parameter(var, graph, 0, quantize_config,
+                                                     ORTOOSExporter.WEIGHT_QUANTIZE_PARAMETER_SUFFIX + ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
+                                                     is_bias=False)
+        if is_bias is False:
+            return quant_val, scale_val, offset_val
+        return quant_val
+
+    def insert_quant_Linear_operation(self, graph: BaseGraph, var: Variable, index: int) -> Operation:
+        quantize_config = var.dest_op_configs[index]
+        quant_op = Operation(name=var.name + ORTOOSExporter.QUANTIZE_LINEAR_SUFFIX,
+                             op_type='QuantizeLinear', attributes={})
+        graph.append_operation(quant_op)
+        link_var = Variable(name=var.name + ORTOOSExporter.LINKER_VAR_SUFFIX, 
+                            dest_ops=[], 
+                            source_op=quant_op)
+        graph.append_variable(link_var)
+        quant_op.inputs.append(var)
+        quant_op.outputs.append(link_var)
+        var.dest_ops[index] = quant_op
+        scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, index, quantize_config, link_to_source=False)
+        quant_op.inputs.extend([scale_val, offset_val])
+        return quant_op
+
+    def insert_dequant_Linear_operation(self, graph: BaseGraph, var: Variable, index: int, is_output_var=False) -> Operation:
+        quantize_config = var.source_op_config
+        dequant_op = Operation(name=var.name + ORTOOSExporter.DEQUANTIZE_LINEAR_SUFFIX,
+                               op_type='DequantizeLinear', attributes={})
+        graph.append_operation(dequant_op)
+        link_var = Variable(name=var.name + ORTOOSExporter.LINKER_VAR_SUFFIX, 
+                            dest_ops=[], 
+                            source_op=dequant_op)
+        graph.append_variable(link_var)
+        dequant_op.inputs.append(var)
+        dequant_op.outputs.append(link_var)
+        # case when DequantizeLinear op required to be inserted before output
+        if is_output_var:
+            var.dest_ops.append(dequant_op)
+        else:
+            var.dest_ops[index] = dequant_op
+        scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, len(var.dest_ops) - 1 if is_output_var else index,
+                                                                quantize_config, link_to_source=False)
+        dequant_op.inputs.extend([scale_val, offset_val])
+        if is_output_var:
+            del graph.outputs[var.name]
+            graph.outputs[link_var.name] = link_var
+        return dequant_op
+
+    def transform_qlinear_conv(self, graph: BaseGraph, op: Operation) -> None:
+        # Input scale
+        input_val_name = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        input_scale, input_offset = graph.variables[input_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+            graph.variables[input_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        # Weight scale
+        weight_val = op.inputs[1]
+        weight_quant, weight_scale, weight_offset = self.add_quant_parameter_for_conv_op(graph, weight_val, False)
+        # Output scale
+        assert len(op.outputs) == 1
+        output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        qlinear_conv_inputs = [op.inputs[0], input_scale, input_offset,
+                               weight_quant, weight_scale, weight_offset,
+                               output_scale, output_offset]
+        graph.delete_variable(op.inputs[1].name, True)
+        # Bias
+        if len(op.inputs) == 3:
+            bias = op.inputs[2]
+            bias_val = self.add_quant_parameter_for_conv_op(graph, bias, True)
+            qlinear_conv_inputs.append(bias_val)
+            graph.delete_variable(op.inputs[2].name, True)
+        op.type = self.qlinear_op_map['Conv']
+        op.inputs.clear()
+        op.inputs.extend(qlinear_conv_inputs)
+
+    def transform_qlinear_add(self, graph: BaseGraph, op: Operation) -> None:
+        # Input scale 0
+        input_val_name_0 = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        if op.inputs[0].is_parameter:
+            input_0, input_scale_0, input_offset_0 = self.add_quant_parameter_for_op(graph, op.inputs[0]) 
+            graph.delete_variable(op.inputs[0].name, True)
+        else:
+            input_0 = op.inputs[0]
+            input_scale_0, input_offset_0 = graph.variables[input_val_name_0 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+                graph.variables[input_val_name_0 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        # Input scale 1
+        input_val_name_1 = op.inputs[1].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        if op.inputs[1].is_parameter:
+            input_1, input_scale_1, input_offset_1 = self.add_quant_parameter_for_op(graph, op.inputs[1]) 
+            graph.delete_variable(op.inputs[1].name, True)
+        else:
+            input_1 = op.inputs[1]
+            input_scale_1, input_offset_1 = graph.variables[input_val_name_1 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+                graph.variables[input_val_name_1 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        # Output scale
+        assert len(op.outputs) == 1
+        output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        qlinear_inputs = [input_0, input_scale_0, input_offset_0,
+                          input_1, input_scale_1, input_offset_1,
+                          output_scale, output_offset]
+        op.type = self.qlinear_op_map['Add']
+        op.attributes['domain'] = 'com.microsoft'
+        op.inputs.clear()
+        op.inputs.extend(qlinear_inputs)
+
+    def transform_qlinear_average_pool(self, graph: BaseGraph, op: Operation, is_global=False) -> None:
+        # Input scale
+        input_val_name = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        input_scale, input_offset = graph.variables[input_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+            graph.variables[input_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        # Output scale
+        assert len(op.outputs) == 1
+        output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        qlinear_inputs = [op.inputs[0], input_scale, input_offset,
+                               output_scale, output_offset]
+        op.type = self.qlinear_op_map['GlobalAveragePool' if is_global is True else 'AveragePool']
+        op.attributes['domain'] = 'com.microsoft'
+        op.inputs.clear()
+        op.inputs.extend(qlinear_inputs)
+
+    def transform_qlinear_matmul(self, graph: BaseGraph, op: Operation, is_global=False) -> None:
+        # Input scale 0
+        input_val_name_0 = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        if op.inputs[0].is_parameter:
+            input_0, input_scale_0, input_offset_0 = self.add_quant_parameter_for_op(graph, op.inputs[0]) 
+            graph.delete_variable(op.inputs[0].name, True)
+        else:
+            input_0 = op.inputs[0]
+            input_scale_0, input_offset_0 = graph.variables[input_val_name_0 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+                graph.variables[input_val_name_0 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        # Input scale 1
+        input_val_name_1 = op.inputs[1].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        if op.inputs[1].is_parameter:
+            input_1, input_scale_1, input_offset_1 = self.add_quant_parameter_for_op(graph, op.inputs[1]) 
+            graph.delete_variable(op.inputs[1].name, True)
+        else:
+            input_1 = op.inputs[1]
+            input_scale_1, input_offset_1 = graph.variables[input_val_name_1 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+                graph.variables[input_val_name_1 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        # Output scale
+        assert len(op.outputs) == 1
+        output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
+        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        qlinear_inputs = [input_0, input_scale_0, input_offset_0,
+                          input_1, input_scale_1, input_offset_1,
+                          output_scale, output_offset]
+        op.type = self.qlinear_op_map['MatMul']
+        op.inputs.clear()
+        op.inputs.extend(qlinear_inputs)
+
+    def transform_qlinear_operation(self, operation: Operation, graph: BaseGraph) -> None:
+        if operation.type == 'Conv':
+            self.transform_qlinear_conv(graph, operation)
+        if operation.type == 'Add':
+            self.transform_qlinear_add(graph, operation)
+        if operation.type == 'GlobalAveragePool':
+            self.transform_qlinear_average_pool(graph, operation, is_global=True)
+        if operation.type == 'AveragePool':
+            self.transform_qlinear_average_pool(graph, operation, is_global=False)
+        if operation.type == 'MatMul':
+            self.transform_qlinear_matmul(graph, operation, is_global=False)
+
+    def correct_param_meta(self, graph: BaseGraph) -> None:
+        # handle QLinear ops
+        for op in graph.topological_sort():
+            if op.type in self.qlinear_ops:
+                curr_meta_len = len(op.meta_data.input_metas)
+                expected_len = len(op.inputs)
+                for _ in range(expected_len - curr_meta_len):
+                    op.meta_data.input_metas.append(TensorMeta(None, None))
+            if op.type == 'QLinearAdd':
+                # the second operand's index move from 1 to 3
+                op.meta_data.input_metas[3] = op.meta_data.input_metas[1]
+                
+        # correct parameter meta data
+        for var in graph.variables.values():
+            if var.is_parameter:
+                for op in var.dest_ops:
+                    if op.meta_data is None:
+                        op.meta_data = OperationMeta([TensorMeta(None, None, v.name) for v in 
+                            op.inputs], [TensorMeta(None, None, v.name) for v in 
+                            op.outputs], op.name, op.type, -1)
+                    
+                    if torch.is_tensor(var.value):
+                        new_input_meta = TensorMeta.parsing_from_torch_tensor(var.value, var.name)
+                    else:
+                        new_input_meta = TensorMeta.parsing_from_numpy_ndarray(var.value, var.name)
+                    
+                    op.meta_data.input_metas[op.inputs.index(var)] = new_input_meta
+
+        # add variable meta info in topo order
+        for op in graph.topological_sort():
+            if op.type == 'QuantizeLinear' and op.inputs[0].source_op is not None:
+                input_var = op.inputs[0]
+                op.meta_data.input_metas[0] = input_var.meta
+                op.meta_data.output_metas[0].shape = input_var.meta.shape
+                op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[2].dtype
+            # must be input
+            elif op.type == 'QuantizeLinear' and op.inputs[0].value is None:
+                var = op.outputs[0]
+                dest_op = var.dest_ops[0]
+                dest_idx = var.dest_idx[0]
+                meta = dest_op.meta_data.input_metas[dest_idx]
+                # meta can't be None itself because we have built TensorMeta 
+                # for every input when we correct param meta
+                while meta.shape is None or meta.dtype is None:
+                    var = dest_op.outputs[0]
+                    dest_op = var.dest_ops[0]
+                    dest_idx = var.dest_idx[0]
+                    meta = dest_op.meta_data.input_metas[dest_idx]
+
+                op.meta_data.input_metas[0] = meta
+                op.meta_data.output_metas[0].shape = meta.shape
+                op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[2].dtype
+            elif op.type == 'DequantizeLinear':
+                input_var = op.inputs[0]
+                op.meta_data.input_metas[0] = input_var.meta
+                op.meta_data.output_metas[0].shape = input_var.meta.shape
+                op.meta_data.output_metas[0].dtype = input_var.meta.dtype
+
+    def export(self, file_path: str, graph: BaseGraph, config_path: str = None) -> None:
+        # remove switchers.
+        if not EXPORT_DEVICE_SWITCHER:
+            processer = GraphDeviceSwitcher(graph)
+            processer.remove_switcher()
+
+        # if a valid config path is given, export quantization config to there.
+        if config_path is not None:
+            super().export_quantization_config(config_path, graph)
+
+        # collect quantable vars, where we need to insert quant and dequant op
+        # note that we assume all quantization configs of the same variable maintained 
+        # by different ops are actually the same
+        quantable_vars,removed_activations = [], []
+        for var in graph.variables.values():
+            if isinstance(var, QuantableVariable):
+                configs = [var.source_op_config] + var.dest_op_configs
+                for cfg in configs:
+                    if cfg is not None and not QuantizationStates.can_export(cfg.state):
+                        raise AttributeError(f"quantization state of variable {var.name} is unexpected, \
+                        please check if you have finished the whole quantization process")
+                    elif cfg is not None and cfg.state not in {QuantizationStates.FP32, QuantizationStates.SOI}:
+                        quantable_vars.append(var)
+                        break
+
+        # Pass 1: remove activations
+        for var in quantable_vars:
+            if var.is_parameter is False and var.source_op is not None and var.source_op.type in ORT_OOS_FUSE_START_OPS and\
+                len(var.dest_ops) == 1 and var.dest_ops[0].type in self.removed_activation_types:
+                removed_activations.extend(var.dest_ops)
+        self.remove_activation(graph, removed_activations)
+
+        # Pass 2: insert QuantizeLinear & DequantizeLinear ops
+        for var in quantable_vars:
+            is_output_var = var.name in graph.outputs
+            # removed activations
+            if not var.dest_ops and is_output_var is False:
+                continue
+            if var.is_parameter is False:
+                # add DequantizeLinear before output if necessary
+                if var.source_op is not None and var.source_op.type in self.qlinear_op_map and\
+                    is_output_var:
+                    self.insert_dequant_Linear_operation(graph, var, 0, True)
+                else:
+                    quant_op = None
+                    dequant_op = None
+                    pop_list = set()
+                    for index, dest_op in enumerate(var.dest_ops):
+                        if var.source_op is not None and var.source_op.type in self.qlinear_op_map and\
+                            dest_op is not None and dest_op.type in self.qlinear_op_map:
+                            self.add_quantize_linear_op_quant_parameter(graph, var, index)
+                        elif var.source_op is not None and var.source_op.type in self.qlinear_op_map: 
+                            if dequant_op is None:
+                                dequant_op = self.insert_dequant_Linear_operation(graph, var, index, False)
+                            dequant_op.outputs[0].dest_ops.append(dest_op)
+                            dest_op.inputs[var.dest_idx[index]] = dequant_op.outputs[0]
+                            if dequant_op in var.dest_ops and var.dest_ops.index(dequant_op) != index:
+                                pop_list.add(dest_op)
+                        elif dest_op.type in self.qlinear_op_map:
+                            if quant_op is None:
+                                quant_op = self.insert_quant_Linear_operation(graph, var, index)
+                            quant_op.outputs[0].dest_ops.append(dest_op)
+                            dest_op.inputs[var.dest_idx[index]] = quant_op.outputs[0]
+                            if quant_op in var.dest_ops and var.dest_ops.index(quant_op) != index:
+                                pop_list.add(dest_op)
+                    # successors which now follows QuantizeLinear/DequantizeLinear ops
+                    for dest_op in pop_list:
+                        pop_index = var.dest_ops.index(dest_op)
+                        var.dest_ops.pop(pop_index)
+
+        # Pass 3 Transform QLinear ops
+        for operation in graph.topological_sort():
+            if operation.type in self.qlinear_op_map:
+                self.transform_qlinear_operation(operation, graph)
+
+        # Pass 4 collect meta info for parameters and newly-added variables
+        self.correct_param_meta(graph)
+
+        # Pass 5 transform other ops
+        self.transform_op(graph)
+
+        name = graph._name
+        if not name: name = 'PPL Quantization Tool - Onnx Export'
+        
+        # Ready to export onnx graph defination.
+        _inputs, _outputs, _initilizers, _nodes = [], [], [], []
+        for operation in graph.topological_sort():
+            _nodes.append(self.export_operation(operation))
+
+        for variable in graph.variables.values():
+            tensor_proto = self.export_var(variable)
+            if variable.name in graph.inputs:
+                _inputs.append(tensor_proto)
+            if variable.name in graph.outputs:
+                _outputs.append(tensor_proto)
+            if variable.is_parameter:
+                _initilizers.append(tensor_proto)
+
+        graph_def = helper.make_graph(
+            name=name,
+            nodes=_nodes,
+            inputs=_inputs,
+            outputs=_outputs,
+            initializer=_initilizers,
+        )
+
+        extra_opsets = self.required_opsets()
+
+        if 'opsets' in graph._detail:
+            opsets = []
+            for opset in graph._detail['opsets']:
+                if opset['domain'] in extra_opsets:
+                    continue
+                op = onnx.OperatorSetIdProto()
+                op.domain = opset['domain']
+                op.version = opset['version']
+                opsets.append(op)
+
+        for key, value in extra_opsets.items():
+            op = onnx.OperatorSetIdProto()
+            op.domain = key
+            op.version = value
+            opsets.append(op)
+
+        onnx_model = helper.make_model(
+            graph_def, producer_name=PPQ_NAME, opset_imports=opsets)
+        onnx_model.ir_version = 7
+        onnx.checker.check_model(onnx_model)
+        onnx.save(onnx_model, file_path)

--- a/ppq/parser/onnxruntime_oos_exporter.py
+++ b/ppq/parser/onnxruntime_oos_exporter.py
@@ -1,9 +1,17 @@
-from typing import Tuple, Union
+from typing import Tuple
+from ppq.IR.quantize import QuantableOperation
 
-from ppq.core import (EXPORT_DEVICE_SWITCHER, QuantizationStates, PPQ_NAME, TensorMeta,
-                      OperationMeta, QuantizationProperty, TensorQuantizationConfig)
-from ppq.core.common import ORT_OOS_FUSE_START_OPS
-from ppq.IR import (BaseGraph, Operation, Variable, QuantableVariable)
+from ppq.core import (
+    EXPORT_DEVICE_SWITCHER,
+    QuantizationStates,
+    PPQ_NAME,
+    TensorMeta,
+    OperationMeta,
+    QuantizationProperty,
+    TensorQuantizationConfig,
+)
+from ppq.core.common import ORT_OOS_FUSE_START_OPS, ORT_MICROSOFT_CONTRIB_LINEAR_OPS
+from ppq.IR import BaseGraph, Operation, Variable, QuantableVariable
 from ppq.IR.morph import GraphDeviceSwitcher
 
 from .onnxruntime_exporter import ONNXRUNTIMExporter
@@ -20,39 +28,51 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
     BIAS_NP_TYPE = np.int32
     SCALE_NP_TYPE = np.float32
 
-    SCALE_PARAMETER_SUFFIX = '_scale'
-    ZP_PARAMETER_SUFFIX = '_zero_point'
-    QUANTIZE_PARAMETER_SUFFIX = '_quantized'
-    WEIGHT_QUANTIZE_PARAMETER_SUFFIX = '_weight'
-    BIAS_QUANTIZE_PARAMETER_SUFFIX = '_bias'
-    LINKER_VAR_SUFFIX = '_linker'
-    QUANTIZE_LINEAR_SUFFIX = '_QuantizeLinear'
-    DEQUANTIZE_LINEAR_SUFFIX = '_DequantizeLinear'
+    SCALE_PARAMETER_SUFFIX = "_scale"
+    ZP_PARAMETER_SUFFIX = "_zero_point"
+    QUANTIZE_PARAMETER_SUFFIX = "_quantized"
+    WEIGHT_QUANTIZE_PARAMETER_SUFFIX = "_weight"
+    BIAS_QUANTIZE_PARAMETER_SUFFIX = "_bias"
+    LINKER_VAR_SUFFIX = "_linker"
+    QUANTIZE_LINEAR_SUFFIX = "_QuantizeLinear"
+    DEQUANTIZE_LINEAR_SUFFIX = "_DequantizeLinear"
 
-    @ property
+    @property
     def qlinear_op_map(self):
         return {
-            'Add': 'QLinearAdd',
-            'AveragePool': 'QLinearAveragePool',
-            'Conv': 'QLinearConv',
-            'GlobalAveragePool': 'QLinearGlobalAveragePool',
-            'MatMul': 'QLinearMatMul',
+            "Add": "QLinearAdd",
+            "Mul": "QLinearMul",
+            "AveragePool": "QLinearAveragePool",
+            "Conv": "QLinearConv",
+            "GlobalAveragePool": "QLinearGlobalAveragePool",
+            "MatMul": "QLinearMatMul",
         }
 
-    @ property
+    @property
     def qlinear_ops(self):
         return self.qlinear_op_map.values()
 
     def get_qlinear_op_type(self, op_type: str) -> str:
         return self.qlinear_op_map.get(op_type, op_type)
-    
-    @ classmethod
+
+    @classmethod
     def get_dtype_on_symmetricity(cls, is_asymmetrical: bool) -> np.dtype:
-        return cls.ASYMMETRICAL_ZP_NP_TYPE if is_asymmetrical else cls.SYMMETRICAL_ZP_NP_TYPE
-    
-    @ classmethod
+        return (
+            cls.ASYMMETRICAL_ZP_NP_TYPE
+            if is_asymmetrical
+            else cls.SYMMETRICAL_ZP_NP_TYPE
+        )
+
+    @classmethod
     def is_quantize_parameter_added(cls, var: Variable, graph: BaseGraph) -> bool:
         return var.name + cls.SCALE_PARAMETER_SUFFIX in graph.variables
+
+    def is_quantized_qlinear_op(self, op: Operation) -> bool:
+        return (
+            op is not None
+            and op.type in self.qlinear_op_map
+            and isinstance(op, QuantableOperation)
+        )
 
     def is_asymmetrical(self, config: TensorQuantizationConfig) -> bool:
         return config.policy.has_property(QuantizationProperty.ASYMMETRICAL)
@@ -60,118 +80,225 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
     def is_per_channel(self, config: TensorQuantizationConfig) -> bool:
         return config.policy.has_property(QuantizationProperty.PER_CHANNEL)
 
-    def build_per_channel_param_broadcast_shape(self, weight: torch.Tensor, param: torch.Tensor) -> torch.Tensor:
-        prefix_count = 0 
-        suffix_count = 0 
+    def build_per_channel_param_broadcast_shape(
+        self, weight: torch.Tensor, param: torch.Tensor
+    ) -> torch.Tensor:
+        prefix_count = 0
+        suffix_count = 0
         while weight.shape[prefix_count] != param.shape[0]:
             prefix_count += 1
         suffix_count = len(weight.shape) - prefix_count - 1
-        return param[(None,)*prefix_count + (...,) + (None,)*suffix_count] 
+        return param[(None,) * prefix_count + (...,) + (None,) * suffix_count]
 
-    def quantize_weight(self, weight: torch.Tensor, scale: torch.Tensor, zero_point: torch.Tensor,
-                        is_asymmetrical: bool, is_per_channel: bool) -> np.ndarray:
+    def quantize_weight(
+        self,
+        weight: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor,
+        is_asymmetrical: bool,
+        is_per_channel: bool,
+    ) -> np.ndarray:
         weight_dtype = self.get_dtype_on_symmetricity(is_asymmetrical)
         if is_per_channel is True:
-            unsqueezed_scale = self.build_per_channel_param_broadcast_shape(weight, scale)
-            unsqueezed_zp = self.build_per_channel_param_broadcast_shape(weight, zero_point)
-            return ((weight / unsqueezed_scale).round() + unsqueezed_zp).numpy().astype(weight_dtype)
+            unsqueezed_scale = self.build_per_channel_param_broadcast_shape(
+                weight, scale
+            )
+            unsqueezed_zp = self.build_per_channel_param_broadcast_shape(
+                weight, zero_point
+            )
+            return (
+                ((weight / unsqueezed_scale).round() + unsqueezed_zp)
+                .numpy()
+                .astype(weight_dtype)
+            )
         else:
             return ((weight / scale).round() + zero_point).numpy().astype(weight_dtype)
 
-    def quantize_bias(self, bias: torch.Tensor, scale: torch.Tensor, zero_point: torch.Tensor) -> np.ndarray:
-        return ((bias / scale).round() + zero_point).numpy().astype(ORTOOSExporter.BIAS_NP_TYPE)
-    
-    def add_scale_and_zp_parameter(self, var: Variable, graph: BaseGraph, dest_index: int,
-                         quantize_config: TensorQuantizationConfig, link_to_source = False) -> Tuple[Variable]:
-        is_asymmetrical = self.is_asymmetrical(quantize_config)
-        offset_dtype = self.get_dtype_on_symmetricity(is_asymmetrical)
-        scale, offset = quantize_config.scale, quantize_config.offset
-        dest_ops = [var.source_op, var.dest_ops[dest_index]] if link_to_source else [var.dest_ops[dest_index]]
-        scale = Variable(name=var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX,
-                         value=np.array(scale, dtype=ORTOOSExporter.SCALE_NP_TYPE),
-                         is_parameter=True,
-                         dest_ops=dest_ops)
-        offset = Variable(name=var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX,
-                          value=np.array(offset, dtype=offset_dtype),
-                          is_parameter=True,
-                          dest_ops=dest_ops)
-        graph.append_variable(scale)
-        graph.append_variable(offset)
+    def quantize_bias(
+        self, bias: torch.Tensor, scale: torch.Tensor, zero_point: torch.Tensor
+    ) -> np.ndarray:
+        return (
+            ((bias / scale).round() + zero_point)
+            .numpy()
+            .astype(ORTOOSExporter.BIAS_NP_TYPE)
+        )
+
+    def add_scale_and_zp_parameter(
+        self,
+        var: Variable,
+        graph: BaseGraph,
+        dest_index: int,
+        quantize_config: TensorQuantizationConfig,
+        link_to_source=False,
+    ) -> Tuple[Variable]:
+        if self.is_quantize_parameter_added(var, graph):
+            scale = graph.variables[var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX]
+            offset = graph.variables[var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+            scale.dest_ops.append(var.dest_ops[dest_index])
+            offset.dest_ops.append(var.dest_ops[dest_index])
+            if link_to_source:
+                scale.dest_ops.append(var.source_op)
+                offset.dest_ops.append(var.source_op)
+        else:
+            is_asymmetrical = self.is_asymmetrical(quantize_config)
+            offset_dtype = self.get_dtype_on_symmetricity(is_asymmetrical)
+            scale, offset = quantize_config.scale, quantize_config.offset
+            dest_ops = (
+                [var.source_op, var.dest_ops[dest_index]]
+                if link_to_source
+                else [var.dest_ops[dest_index]]
+            )
+            scale = Variable(
+                name=var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX,
+                value=np.array(scale, dtype=ORTOOSExporter.SCALE_NP_TYPE),
+                is_parameter=True,
+                dest_ops=dest_ops,
+            )
+            offset = Variable(
+                name=var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX,
+                value=np.array(offset, dtype=offset_dtype),
+                is_parameter=True,
+                dest_ops=dest_ops,
+            )
+            graph.append_variable(scale)
+            graph.append_variable(offset)
         return scale, offset
-    
-    def add_quantized_parameter(self, var: Variable, graph: BaseGraph, dest_index: int,
-                                   quantize_config: TensorQuantizationConfig, quantize_suffix: str, is_bias: bool) -> Variable:
+
+    def add_quantized_parameter(
+        self,
+        var: Variable,
+        graph: BaseGraph,
+        dest_index: int,
+        quantize_config: TensorQuantizationConfig,
+        quantize_suffix: str,
+        is_bias: bool,
+    ) -> Variable:
         scale, offset = quantize_config.scale, quantize_config.offset
         if is_bias:
             quant_value = self.quantize_bias(var.value, scale, offset)
         else:
             is_asymmetrical = self.is_asymmetrical(quantize_config)
             is_per_channel = self.is_per_channel(quantize_config)
-            quant_value = self.quantize_weight(var.value, scale, offset, is_asymmetrical, is_per_channel)
-        quant_val = Variable(name=var.name + quantize_suffix,
-                             value=quant_value,
-                             is_parameter=True,
-                             dest_ops=[var.dest_ops[dest_index]])
+            quant_value = self.quantize_weight(
+                var.value, scale, offset, is_asymmetrical, is_per_channel
+            )
+        quant_val = Variable(
+            name=var.name + quantize_suffix,
+            value=quant_value,
+            is_parameter=True,
+            dest_ops=[var.dest_ops[dest_index]],
+        )
         graph.append_variable(quant_val)
         return quant_val
 
-    def add_quantize_linear_op_quant_parameter(self, graph: BaseGraph, var: Variable, index: int) -> None:
+    def add_quantize_linear_op_quant_parameter(
+        self, graph: BaseGraph, var: Variable, index: int
+    ) -> None:
         if self.is_quantize_parameter_added(var, graph):
             # quantization parameter would be shared by multiple operations
-            graph.variables[var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX].dest_ops.append(var.dest_ops[index])
-            graph.variables[var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX].dest_ops.append(var.dest_ops[index])
+            graph.variables[
+                var.name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX
+            ].dest_ops.append(var.dest_ops[index])
+            graph.variables[
+                var.name + ORTOOSExporter.ZP_PARAMETER_SUFFIX
+            ].dest_ops.append(var.dest_ops[index])
         else:
             # add new quantization parameter
             quantize_config = var.source_op_config
-            self.add_scale_and_zp_parameter(var, graph, index, quantize_config, link_to_source=True)
-    
-    def add_quant_parameter_for_op(self, graph: BaseGraph, var: Variable) -> Tuple[Variable]:
+            self.add_scale_and_zp_parameter(
+                var, graph, index, quantize_config, link_to_source=True
+            )
+
+    def add_quant_parameter_for_op(
+        self, graph: BaseGraph, var: Variable
+    ) -> Tuple[Variable]:
         assert len(var.dest_ops) == 1
         quantize_config = var.dest_op_configs[0]
-        scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, 0, quantize_config, link_to_source=False)
-        quant_val = self.add_quantized_parameter(var, graph, 0, quantize_config, ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX, is_bias=False)
+        scale_val, offset_val = self.add_scale_and_zp_parameter(
+            var, graph, 0, quantize_config, link_to_source=False
+        )
+        quant_val = self.add_quantized_parameter(
+            var,
+            graph,
+            0,
+            quantize_config,
+            ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
+            is_bias=False,
+        )
         return quant_val, scale_val, offset_val
 
-    def add_quant_parameter_for_conv_op(self, graph: BaseGraph, var: Variable, is_bias: bool) -> Tuple[Variable]:
+    def add_quant_parameter_for_conv_op(
+        self, graph: BaseGraph, var: Variable, is_bias: bool
+    ) -> Tuple[Variable]:
         assert len(var.dest_ops) == 1
         quantize_config = var.dest_op_configs[0]
         if is_bias is True:
-            quant_val = self.add_quantized_parameter(var, graph, 0, quantize_config,
-                                                     ORTOOSExporter.BIAS_QUANTIZE_PARAMETER_SUFFIX + ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
-                                                     is_bias=True)
+            quant_val = self.add_quantized_parameter(
+                var,
+                graph,
+                0,
+                quantize_config,
+                ORTOOSExporter.BIAS_QUANTIZE_PARAMETER_SUFFIX
+                + ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
+                is_bias=True,
+            )
         else:
-            scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, 0, quantize_config, link_to_source=False)
-            quant_val = self.add_quantized_parameter(var, graph, 0, quantize_config,
-                                                     ORTOOSExporter.WEIGHT_QUANTIZE_PARAMETER_SUFFIX + ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
-                                                     is_bias=False)
+            scale_val, offset_val = self.add_scale_and_zp_parameter(
+                var, graph, 0, quantize_config, link_to_source=False
+            )
+            quant_val = self.add_quantized_parameter(
+                var,
+                graph,
+                0,
+                quantize_config,
+                ORTOOSExporter.WEIGHT_QUANTIZE_PARAMETER_SUFFIX
+                + ORTOOSExporter.QUANTIZE_PARAMETER_SUFFIX,
+                is_bias=False,
+            )
         if is_bias is False:
             return quant_val, scale_val, offset_val
         return quant_val
 
-    def insert_quant_Linear_operation(self, graph: BaseGraph, var: Variable, index: int) -> Operation:
+    def insert_quant_Linear_operation(
+        self, graph: BaseGraph, var: Variable, index: int
+    ) -> Operation:
         quantize_config = var.dest_op_configs[index]
-        quant_op = Operation(name=var.name + ORTOOSExporter.QUANTIZE_LINEAR_SUFFIX,
-                             op_type='QuantizeLinear', attributes={})
+        quant_op = Operation(
+            name=var.name + ORTOOSExporter.QUANTIZE_LINEAR_SUFFIX,
+            op_type="QuantizeLinear",
+            attributes={},
+        )
         graph.append_operation(quant_op)
-        link_var = Variable(name=var.name + ORTOOSExporter.LINKER_VAR_SUFFIX, 
-                            dest_ops=[], 
-                            source_op=quant_op)
+        link_var = Variable(
+            name=var.name + ORTOOSExporter.LINKER_VAR_SUFFIX,
+            dest_ops=[],
+            source_op=quant_op,
+        )
         graph.append_variable(link_var)
         quant_op.inputs.append(var)
         quant_op.outputs.append(link_var)
         var.dest_ops[index] = quant_op
-        scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, index, quantize_config, link_to_source=False)
+        scale_val, offset_val = self.add_scale_and_zp_parameter(
+            var, graph, index, quantize_config, link_to_source=False
+        )
         quant_op.inputs.extend([scale_val, offset_val])
         return quant_op
 
-    def insert_dequant_Linear_operation(self, graph: BaseGraph, var: Variable, index: int, is_output_var=False) -> Operation:
+    def insert_dequant_Linear_operation(
+        self, graph: BaseGraph, var: Variable, index: int, is_output_var=False
+    ) -> Operation:
         quantize_config = var.source_op_config
-        dequant_op = Operation(name=var.name + ORTOOSExporter.DEQUANTIZE_LINEAR_SUFFIX,
-                               op_type='DequantizeLinear', attributes={})
+        dequant_op = Operation(
+            name=var.name + ORTOOSExporter.DEQUANTIZE_LINEAR_SUFFIX,
+            op_type="DequantizeLinear",
+            attributes={},
+        )
         graph.append_operation(dequant_op)
-        link_var = Variable(name=var.name + ORTOOSExporter.LINKER_VAR_SUFFIX, 
-                            dest_ops=[], 
-                            source_op=dequant_op)
+        link_var = Variable(
+            name=var.name + ORTOOSExporter.LINKER_VAR_SUFFIX,
+            dest_ops=[],
+            source_op=dequant_op,
+        )
         graph.append_variable(link_var)
         dequant_op.inputs.append(var)
         dequant_op.outputs.append(link_var)
@@ -180,8 +307,13 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
             var.dest_ops.append(dequant_op)
         else:
             var.dest_ops[index] = dequant_op
-        scale_val, offset_val = self.add_scale_and_zp_parameter(var, graph, len(var.dest_ops) - 1 if is_output_var else index,
-                                                                quantize_config, link_to_source=False)
+        scale_val, offset_val = self.add_scale_and_zp_parameter(
+            var,
+            graph,
+            len(var.dest_ops) - 1 if is_output_var else index,
+            quantize_config,
+            link_to_source=False,
+        )
         dequant_op.inputs.extend([scale_val, offset_val])
         if is_output_var:
             del graph.outputs[var.name]
@@ -191,19 +323,34 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
     def transform_qlinear_conv(self, graph: BaseGraph, op: Operation) -> None:
         # Input scale
         input_val_name = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
-        input_scale, input_offset = graph.variables[input_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-            graph.variables[input_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        input_scale, input_offset = (
+            graph.variables[input_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],
+            graph.variables[input_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+        )
         # Weight scale
         weight_val = op.inputs[1]
-        weight_quant, weight_scale, weight_offset = self.add_quant_parameter_for_conv_op(graph, weight_val, False)
+        (
+            weight_quant,
+            weight_scale,
+            weight_offset,
+        ) = self.add_quant_parameter_for_conv_op(graph, weight_val, False)
         # Output scale
         assert len(op.outputs) == 1
         output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
-        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
-        qlinear_conv_inputs = [op.inputs[0], input_scale, input_offset,
-                               weight_quant, weight_scale, weight_offset,
-                               output_scale, output_offset]
+        output_scale, output_offset = (
+            graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+        )
+        qlinear_conv_inputs = [
+            op.inputs[0],
+            input_scale,
+            input_offset,
+            weight_quant,
+            weight_scale,
+            weight_offset,
+            output_scale,
+            output_offset,
+        ]
         graph.delete_variable(op.inputs[1].name, True)
         # Bias
         if len(op.inputs) == 3:
@@ -211,100 +358,160 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
             bias_val = self.add_quant_parameter_for_conv_op(graph, bias, True)
             qlinear_conv_inputs.append(bias_val)
             graph.delete_variable(op.inputs[2].name, True)
-        op.type = self.qlinear_op_map['Conv']
+        op.type = self.qlinear_op_map["Conv"]
         op.inputs.clear()
         op.inputs.extend(qlinear_conv_inputs)
 
-    def transform_qlinear_add(self, graph: BaseGraph, op: Operation) -> None:
+    def transform_qlinear_linear_op(self, graph: BaseGraph, op: Operation) -> None:
         # Input scale 0
         input_val_name_0 = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
         if op.inputs[0].is_parameter:
-            input_0, input_scale_0, input_offset_0 = self.add_quant_parameter_for_op(graph, op.inputs[0]) 
+            input_0, input_scale_0, input_offset_0 = self.add_quant_parameter_for_op(
+                graph, op.inputs[0]
+            )
             graph.delete_variable(op.inputs[0].name, True)
         else:
             input_0 = op.inputs[0]
-            input_scale_0, input_offset_0 = graph.variables[input_val_name_0 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-                graph.variables[input_val_name_0 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+            input_scale_0, input_offset_0 = (
+                graph.variables[
+                    input_val_name_0 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX
+                ],
+                graph.variables[input_val_name_0 + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+            )
         # Input scale 1
         input_val_name_1 = op.inputs[1].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
         if op.inputs[1].is_parameter:
-            input_1, input_scale_1, input_offset_1 = self.add_quant_parameter_for_op(graph, op.inputs[1]) 
+            input_1, input_scale_1, input_offset_1 = self.add_quant_parameter_for_op(
+                graph, op.inputs[1]
+            )
             graph.delete_variable(op.inputs[1].name, True)
         else:
             input_1 = op.inputs[1]
-            input_scale_1, input_offset_1 = graph.variables[input_val_name_1 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-                graph.variables[input_val_name_1 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+            input_scale_1, input_offset_1 = (
+                graph.variables[
+                    input_val_name_1 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX
+                ],
+                graph.variables[input_val_name_1 + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+            )
         # Output scale
         assert len(op.outputs) == 1
         output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
-        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
-        qlinear_inputs = [input_0, input_scale_0, input_offset_0,
-                          input_1, input_scale_1, input_offset_1,
-                          output_scale, output_offset]
-        op.type = self.qlinear_op_map['Add']
-        op.attributes['domain'] = 'com.microsoft'
+        output_scale, output_offset = (
+            graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+        )
+        qlinear_inputs = [
+            input_0,
+            input_scale_0,
+            input_offset_0,
+            input_1,
+            input_scale_1,
+            input_offset_1,
+            output_scale,
+            output_offset,
+        ]
+        if op.type in ORT_MICROSOFT_CONTRIB_LINEAR_OPS:
+            op.attributes["domain"] = "com.microsoft"
+        op.type = self.qlinear_op_map[op.type]
         op.inputs.clear()
         op.inputs.extend(qlinear_inputs)
 
-    def transform_qlinear_average_pool(self, graph: BaseGraph, op: Operation, is_global=False) -> None:
+    def transform_qlinear_average_pool(
+        self, graph: BaseGraph, op: Operation, is_global=False
+    ) -> None:
         # Input scale
         input_val_name = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
-        input_scale, input_offset = graph.variables[input_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-            graph.variables[input_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+        input_scale, input_offset = (
+            graph.variables[input_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],
+            graph.variables[input_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+        )
         # Output scale
         assert len(op.outputs) == 1
         output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
-        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
-        qlinear_inputs = [op.inputs[0], input_scale, input_offset,
-                               output_scale, output_offset]
-        op.type = self.qlinear_op_map['GlobalAveragePool' if is_global is True else 'AveragePool']
-        op.attributes['domain'] = 'com.microsoft'
+        output_scale, output_offset = (
+            graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+        )
+        qlinear_inputs = [
+            op.inputs[0],
+            input_scale,
+            input_offset,
+            output_scale,
+            output_offset,
+        ]
+        op.type = self.qlinear_op_map[
+            "GlobalAveragePool" if is_global is True else "AveragePool"
+        ]
+        op.attributes["domain"] = "com.microsoft"
         op.inputs.clear()
         op.inputs.extend(qlinear_inputs)
 
-    def transform_qlinear_matmul(self, graph: BaseGraph, op: Operation, is_global=False) -> None:
+    def transform_qlinear_matmul(
+        self, graph: BaseGraph, op: Operation, is_global=False
+    ) -> None:
         # Input scale 0
         input_val_name_0 = op.inputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
         if op.inputs[0].is_parameter:
-            input_0, input_scale_0, input_offset_0 = self.add_quant_parameter_for_op(graph, op.inputs[0]) 
+            input_0, input_scale_0, input_offset_0 = self.add_quant_parameter_for_op(
+                graph, op.inputs[0]
+            )
             graph.delete_variable(op.inputs[0].name, True)
         else:
             input_0 = op.inputs[0]
-            input_scale_0, input_offset_0 = graph.variables[input_val_name_0 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-                graph.variables[input_val_name_0 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+            input_scale_0, input_offset_0 = (
+                graph.variables[
+                    input_val_name_0 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX
+                ],
+                graph.variables[input_val_name_0 + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+            )
         # Input scale 1
         input_val_name_1 = op.inputs[1].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
         if op.inputs[1].is_parameter:
-            input_1, input_scale_1, input_offset_1 = self.add_quant_parameter_for_op(graph, op.inputs[1]) 
+            input_1, input_scale_1, input_offset_1 = self.add_quant_parameter_for_op(
+                graph, op.inputs[1]
+            )
             graph.delete_variable(op.inputs[1].name, True)
         else:
             input_1 = op.inputs[1]
-            input_scale_1, input_offset_1 = graph.variables[input_val_name_1 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-                graph.variables[input_val_name_1 + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
+            input_scale_1, input_offset_1 = (
+                graph.variables[
+                    input_val_name_1 + ORTOOSExporter.SCALE_PARAMETER_SUFFIX
+                ],
+                graph.variables[input_val_name_1 + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+            )
         # Output scale
         assert len(op.outputs) == 1
         output_val_name = op.outputs[0].name.split(ORTOOSExporter.LINKER_VAR_SUFFIX)[0]
-        output_scale, output_offset = graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],\
-            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX]
-        qlinear_inputs = [input_0, input_scale_0, input_offset_0,
-                          input_1, input_scale_1, input_offset_1,
-                          output_scale, output_offset]
-        op.type = self.qlinear_op_map['MatMul']
+        output_scale, output_offset = (
+            graph.variables[output_val_name + ORTOOSExporter.SCALE_PARAMETER_SUFFIX],
+            graph.variables[output_val_name + ORTOOSExporter.ZP_PARAMETER_SUFFIX],
+        )
+        qlinear_inputs = [
+            input_0,
+            input_scale_0,
+            input_offset_0,
+            input_1,
+            input_scale_1,
+            input_offset_1,
+            output_scale,
+            output_offset,
+        ]
+        op.type = self.qlinear_op_map["MatMul"]
         op.inputs.clear()
         op.inputs.extend(qlinear_inputs)
 
-    def transform_qlinear_operation(self, operation: Operation, graph: BaseGraph) -> None:
-        if operation.type == 'Conv':
+    def transform_qlinear_operation(
+        self, operation: Operation, graph: BaseGraph
+    ) -> None:
+        if operation.type == "Conv":
             self.transform_qlinear_conv(graph, operation)
-        if operation.type == 'Add':
-            self.transform_qlinear_add(graph, operation)
-        if operation.type == 'GlobalAveragePool':
+        if operation.type in ["Add", "Mul"]:
+            self.transform_qlinear_linear_op(graph, operation)
+        if operation.type == "GlobalAveragePool":
             self.transform_qlinear_average_pool(graph, operation, is_global=True)
-        if operation.type == 'AveragePool':
+        if operation.type == "AveragePool":
             self.transform_qlinear_average_pool(graph, operation, is_global=False)
-        if operation.type == 'MatMul':
+        if operation.type == "MatMul":
             self.transform_qlinear_matmul(graph, operation, is_global=False)
 
     def correct_param_meta(self, graph: BaseGraph) -> None:
@@ -315,40 +522,48 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
                 expected_len = len(op.inputs)
                 for _ in range(expected_len - curr_meta_len):
                     op.meta_data.input_metas.append(TensorMeta(None, None))
-            if op.type == 'QLinearAdd':
+            if op.type == "QLinearAdd":
                 # the second operand's index move from 1 to 3
                 op.meta_data.input_metas[3] = op.meta_data.input_metas[1]
-                
+
         # correct parameter meta data
         for var in graph.variables.values():
             if var.is_parameter:
                 for op in var.dest_ops:
                     if op.meta_data is None:
-                        op.meta_data = OperationMeta([TensorMeta(None, None, v.name) for v in 
-                            op.inputs], [TensorMeta(None, None, v.name) for v in 
-                            op.outputs], op.name, op.type, -1)
-                    
+                        op.meta_data = OperationMeta(
+                            [TensorMeta(None, None, v.name) for v in op.inputs],
+                            [TensorMeta(None, None, v.name) for v in op.outputs],
+                            op.name,
+                            op.type,
+                            -1,
+                        )
+
                     if torch.is_tensor(var.value):
-                        new_input_meta = TensorMeta.parsing_from_torch_tensor(var.value, var.name)
+                        new_input_meta = TensorMeta.parsing_from_torch_tensor(
+                            var.value, var.name
+                        )
                     else:
-                        new_input_meta = TensorMeta.parsing_from_numpy_ndarray(var.value, var.name)
-                    
+                        new_input_meta = TensorMeta.parsing_from_numpy_ndarray(
+                            var.value, var.name
+                        )
+
                     op.meta_data.input_metas[op.inputs.index(var)] = new_input_meta
 
         # add variable meta info in topo order
         for op in graph.topological_sort():
-            if op.type == 'QuantizeLinear' and op.inputs[0].source_op is not None:
+            if op.type == "QuantizeLinear" and op.inputs[0].source_op is not None:
                 input_var = op.inputs[0]
                 op.meta_data.input_metas[0] = input_var.meta
                 op.meta_data.output_metas[0].shape = input_var.meta.shape
                 op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[2].dtype
             # must be input
-            elif op.type == 'QuantizeLinear' and op.inputs[0].value is None:
+            elif op.type == "QuantizeLinear" and op.inputs[0].value is None:
                 var = op.outputs[0]
                 dest_op = var.dest_ops[0]
                 dest_idx = var.dest_idx[0]
                 meta = dest_op.meta_data.input_metas[dest_idx]
-                # meta can't be None itself because we have built TensorMeta 
+                # meta can't be None itself because we have built TensorMeta
                 # for every input when we correct param meta
                 while meta.shape is None or meta.dtype is None:
                     var = dest_op.outputs[0]
@@ -359,7 +574,7 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
                 op.meta_data.input_metas[0] = meta
                 op.meta_data.output_metas[0].shape = meta.shape
                 op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[2].dtype
-            elif op.type == 'DequantizeLinear':
+            elif op.type == "DequantizeLinear":
                 input_var = op.inputs[0]
                 op.meta_data.input_metas[0] = input_var.meta
                 op.meta_data.output_metas[0].shape = input_var.meta.shape
@@ -376,24 +591,34 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
             super().export_quantization_config(config_path, graph)
 
         # collect quantable vars, where we need to insert quant and dequant op
-        # note that we assume all quantization configs of the same variable maintained 
+        # note that we assume all quantization configs of the same variable maintained
         # by different ops are actually the same
-        quantable_vars,removed_activations = [], []
+        quantable_vars, removed_activations = [], []
         for var in graph.variables.values():
             if isinstance(var, QuantableVariable):
                 configs = [var.source_op_config] + var.dest_op_configs
                 for cfg in configs:
                     if cfg is not None and not QuantizationStates.can_export(cfg.state):
-                        raise AttributeError(f"quantization state of variable {var.name} is unexpected, \
-                        please check if you have finished the whole quantization process")
-                    elif cfg is not None and cfg.state not in {QuantizationStates.FP32, QuantizationStates.SOI}:
+                        raise AttributeError(
+                            f"quantization state of variable {var.name} is unexpected, \
+                        please check if you have finished the whole quantization process"
+                        )
+                    elif cfg is not None and cfg.state not in {
+                        QuantizationStates.FP32,
+                        QuantizationStates.SOI,
+                    }:
                         quantable_vars.append(var)
                         break
 
         # Pass 1: remove activations
         for var in quantable_vars:
-            if var.is_parameter is False and var.source_op is not None and var.source_op.type in ORT_OOS_FUSE_START_OPS and\
-                len(var.dest_ops) == 1 and var.dest_ops[0].type in self.removed_activation_types:
+            if (
+                var.is_parameter is False
+                and var.source_op is not None
+                and var.source_op.type in ORT_OOS_FUSE_START_OPS
+                and len(var.dest_ops) == 1
+                and var.dest_ops[0].type in self.removed_activation_types
+            ):
                 removed_activations.extend(var.dest_ops)
         self.remove_activation(graph, removed_activations)
 
@@ -405,39 +630,62 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
                 continue
             if var.is_parameter is False:
                 # add DequantizeLinear before output if necessary
-                if var.source_op is not None and var.source_op.type in self.qlinear_op_map and\
-                    is_output_var:
+                if (
+                    var.source_op is not None
+                    and var.source_op.type in self.qlinear_op_map
+                    and is_output_var
+                ):
                     self.insert_dequant_Linear_operation(graph, var, 0, True)
                 else:
                     quant_op = None
                     dequant_op = None
-                    pop_list = set()
+                    pop_list = []
+                    relink_node_pair = []
                     for index, dest_op in enumerate(var.dest_ops):
-                        if var.source_op is not None and var.source_op.type in self.qlinear_op_map and\
-                            dest_op is not None and dest_op.type in self.qlinear_op_map:
-                            self.add_quantize_linear_op_quant_parameter(graph, var, index)
-                        elif var.source_op is not None and var.source_op.type in self.qlinear_op_map: 
+                        if self.is_quantized_qlinear_op(
+                            var.source_op
+                        ) and self.is_quantized_qlinear_op(dest_op):
+                            self.add_quantize_linear_op_quant_parameter(
+                                graph, var, index
+                            )
+                        elif var.source_op is not None and self.is_quantized_qlinear_op(
+                            var.source_op
+                        ):
+                            old_index = var.dest_idx[index]
                             if dequant_op is None:
-                                dequant_op = self.insert_dequant_Linear_operation(graph, var, index, False)
+                                dequant_op = self.insert_dequant_Linear_operation(
+                                    graph, var, index, False
+                                )
                             dequant_op.outputs[0].dest_ops.append(dest_op)
-                            dest_op.inputs[var.dest_idx[index]] = dequant_op.outputs[0]
-                            if dequant_op in var.dest_ops and var.dest_ops.index(dequant_op) != index:
-                                pop_list.add(dest_op)
-                        elif dest_op.type in self.qlinear_op_map:
+                            relink_node_pair.append((dest_op, old_index, dequant_op))
+                            if (
+                                dequant_op in var.dest_ops
+                                and var.dest_ops.index(dequant_op) != index
+                            ):
+                                pop_list.append(dest_op)
+                        elif self.is_quantized_qlinear_op(dest_op):
+                            old_index = var.dest_idx[index]
                             if quant_op is None:
-                                quant_op = self.insert_quant_Linear_operation(graph, var, index)
+                                quant_op = self.insert_quant_Linear_operation(
+                                    graph, var, index
+                                )
                             quant_op.outputs[0].dest_ops.append(dest_op)
-                            dest_op.inputs[var.dest_idx[index]] = quant_op.outputs[0]
-                            if quant_op in var.dest_ops and var.dest_ops.index(quant_op) != index:
-                                pop_list.add(dest_op)
+                            relink_node_pair.append((dest_op, old_index, quant_op))
+                            if (
+                                quant_op in var.dest_ops
+                                and var.dest_ops.index(quant_op) != index
+                            ):
+                                pop_list.append(dest_op)
                     # successors which now follows QuantizeLinear/DequantizeLinear ops
                     for dest_op in pop_list:
                         pop_index = var.dest_ops.index(dest_op)
                         var.dest_ops.pop(pop_index)
+                    for node, index, quantize_node in relink_node_pair:
+                        node.inputs[index] = quantize_node.outputs[0]
 
         # Pass 3 Transform QLinear ops
         for operation in graph.topological_sort():
-            if operation.type in self.qlinear_op_map:
+            if self.is_quantized_qlinear_op(operation):
                 self.transform_qlinear_operation(operation, graph)
 
         # Pass 4 collect meta info for parameters and newly-added variables
@@ -447,8 +695,9 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
         self.transform_op(graph)
 
         name = graph._name
-        if not name: name = 'PPL Quantization Tool - Onnx Export'
-        
+        if not name:
+            name = "PPL Quantization Tool - Onnx Export"
+
         # Ready to export onnx graph defination.
         _inputs, _outputs, _initilizers, _nodes = [], [], [], []
         for operation in graph.topological_sort():
@@ -473,15 +722,15 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
 
         extra_opsets = self.required_opsets()
 
-        if 'opsets' in graph._detail:
+        if "opsets" in graph._detail:
             opsets = []
-            for opset in graph._detail['opsets']:
+            for opset in graph._detail["opsets"]:
                 # last condition shall be removed if we wanna run checker
-                if opset['domain'] in extra_opsets or opset['domain'] == '':
+                if opset["domain"] in extra_opsets or opset["domain"] == "":
                     continue
                 op = onnx.OperatorSetIdProto()
-                op.domain = opset['domain']
-                op.version = opset['version']
+                op.domain = opset["domain"]
+                op.version = opset["version"]
                 opsets.append(op)
 
         for key, value in extra_opsets.items():
@@ -491,7 +740,8 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
             opsets.append(op)
 
         onnx_model = helper.make_model(
-            graph_def, producer_name=PPQ_NAME, opset_imports=opsets)
+            graph_def, producer_name=PPQ_NAME, opset_imports=opsets
+        )
         onnx_model.ir_version = 7
         # onnx.checker.check_model(onnx_model)
         onnx.save(onnx_model, file_path)

--- a/ppq/quantization/optim/refine.py
+++ b/ppq/quantization/optim/refine.py
@@ -4,6 +4,7 @@ from typing import Iterable, List
 from ppq.core import (COMPELING_OP_TYPES, PPLCUDA_ACTIVATIONS,
                       QuantizationStates, RoundingPolicy, TargetPlatform,
                       empty_ppq_cache)
+from ppq.core.common import ORT_OOS_FUSE_START_OPS
 from ppq.executor import BaseGraphExecutor
 from ppq.IR import GraphCommandProcesser, QuantableOperation, Variable
 from ppq.IR.base.graph import Operation
@@ -358,6 +359,12 @@ class QuantizeFusionPass(QuantizationOptimizationPass):
                     rp_expr=lambda x, y: False,
                     ep_expr=lambda x: (x.type in PPLCUDA_ACTIVATIONS or 
                                        x.is_linear_activation),
+                    direction='down')
+            elif self.platform == TargetPlatform.ORT_OOS_INT8:
+                computing_act_matching = processer.path_matching(
+                    sp_expr=lambda x: x.type in ORT_OOS_FUSE_START_OPS,
+                    rp_expr=lambda x, y: False,
+                    ep_expr=lambda x: x.is_linear_activation,
                     direction='down')
             else:
                 computing_act_matching = processer.path_matching(

--- a/ppq/quantization/quantizer/ORTQuantizer.py
+++ b/ppq/quantization/quantizer/ORTQuantizer.py
@@ -69,7 +69,7 @@ class ORT_PerTensorQuantizer(BaseQuantizer):
     def quant_operation_types(self) -> set:
         return {
             'Conv', 'GlobalAveragePool', 'AveragePool',
-            'Relu', 'Add', 'Clip',
+            'Relu', 'Add', 'Mul', 'Clip',
             'MatMul'
         }
 
@@ -181,7 +181,7 @@ class ORT_PerChannelQuantizer(BaseQuantizer):
     def quant_operation_types(self) -> set:
         return {
             'Conv', 'GlobalAveragePool', 'AveragePool',
-            'Relu', 'Add', 'Clip',
+            'Relu', 'Add', 'Mul', 'Clip',
             'MatMul'
         }
 

--- a/ppq/quantization/quantizer/ORTQuantizer.py
+++ b/ppq/quantization/quantizer/ORTQuantizer.py
@@ -153,7 +153,7 @@ class ORT_PerChannelQuantizer(BaseQuantizer):
                     QuantizationProperty.LINEAR +
                     QuantizationProperty.PER_CHANNEL
                 )
-                bias_config.num_of_bits = 32
+                bias_config.num_of_bits = 30
                 bias_config.quant_max = int(pow(2, bias_config.num_of_bits - 1)) - 1
                 bias_config.quant_min = - int(pow(2, bias_config.num_of_bits - 1)) + 1
                 bias_config.state = QuantizationStates.PASSIVE_INIT

--- a/ppq/quantization/quantizer/ORTQuantizer.py
+++ b/ppq/quantization/quantizer/ORTQuantizer.py
@@ -1,0 +1,198 @@
+from typing import Union
+
+from ppq.core import (PASSIVE_OPERATIONS, OperationQuantizationConfig, ChannelwiseTensorQuantizationConfig,
+                      QuantizationPolicy, QuantizationProperty,
+                      QuantizationStates, RoundingPolicy, TargetPlatform)
+from ppq.IR import BaseGraph, GraphCommandProcesser
+from ppq.IR.base.graph import Operation
+
+from .base import BaseQuantizer
+
+import torch
+
+
+class ORT_PerTensorQuantizer(BaseQuantizer):
+    def __init__(
+        self,
+        graph: Union[BaseGraph, GraphCommandProcesser]
+    ) -> Union[torch.Tensor, list, dict]:
+
+        self._num_of_bits = 8
+        self._quant_min = 0
+        self._quant_max = int(pow(2, self._num_of_bits) - 1)
+
+        super().__init__(graph=graph)
+
+    def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
+
+        base_quant_config = self.create_default_quant_config(
+            operation_meta=operation.meta_data, num_of_bits=self._num_of_bits,
+            quant_max=self._quant_max, quant_min=self._quant_min,
+            observer_algorithm='percentile', policy=self.quantize_policy,
+            rounding=self.rounding_policy,
+        )
+
+        if operation.type in {'Conv'}:
+            # if operation has bias
+            if operation.num_of_input == 3:
+                bias_config = base_quant_config.input_quantization_config[-1]
+                # bias should be quantized with 32 bits
+                # in python3, int indicates long long in C++
+                # so that it has enough precision to represent a number like 2^32
+                # however, it may cause a scale underflow
+                # here we give bias a 30 bits precision, which is pettery enough in all cases
+                bias_config.num_of_bits = 30
+                bias_config.quant_max = int(pow(2, 30 - 1) - 1)
+                bias_config.quant_min = - int(pow(2, 30 - 1))
+                bias_config.policy = QuantizationPolicy(
+                    QuantizationProperty.SYMMETRICAL +
+                    QuantizationProperty.LINEAR +
+                    QuantizationProperty.PER_TENSOR)
+                bias_config.state = QuantizationStates.PASSIVE_INIT
+            for config in base_quant_config.input_quantization_config[1: ]:
+                config.observer_algorithm = 'minmax'
+
+        if operation.type in PASSIVE_OPERATIONS:
+            # Those op are not active op.
+            base_quant_config.is_active_quant_op = False
+        return base_quant_config
+
+    @ property
+    def target_platform(self) -> TargetPlatform:
+        return TargetPlatform.ORT_OOS_INT8
+
+    @ property
+    def default_platform(self) -> TargetPlatform:
+        return TargetPlatform.FP32
+
+    @ property
+    def quant_operation_types(self) -> set:
+        return {
+            'Conv', 'GlobalAveragePool', 'AveragePool',
+            'Relu', 'Add', 'Clip',
+            'MatMul'
+        }
+
+    @ property
+    def quantize_policy(self) -> QuantizationPolicy:
+        return QuantizationPolicy(
+            QuantizationProperty.ASYMMETRICAL +
+            QuantizationProperty.LINEAR +
+            QuantizationProperty.PER_TENSOR
+        )
+
+    @ property
+    def rounding_policy(self) -> RoundingPolicy:
+        return RoundingPolicy.ROUND_HALF_EVEN
+
+
+class ORT_PerChannelQuantizer(BaseQuantizer):
+    def __init__(
+        self, graph: Union[BaseGraph, GraphCommandProcesser]
+    ) -> Union[torch.Tensor, list, dict]:
+
+        self._num_of_bits = 8
+        self._quant_min = 0
+        self._quant_max = int(pow(2, self._num_of_bits) - 1)
+
+        super().__init__(graph=graph)
+
+    def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
+        base_quant_config = self.create_default_quant_config(
+            policy=self.quantize_policy, rounding=self.rounding_policy,
+            operation_meta=operation.meta_data, num_of_bits=self._num_of_bits,
+            quant_max=self._quant_max, quant_min=self._quant_min,
+            observer_algorithm='percentile'
+        )
+        
+        if operation.type in {'Conv', 'MatMul'}:
+            # set all parameters within Conv, ConvTranspose, Gemm to per-channel quant-config.
+            assert operation.num_of_input > 0, 'Seems you got a Conv layer with no parameters.'
+
+            # first parameter must exits, for conv layer it will be conv_weight
+            # layout: [out_channel, in_channel, kernel_size, kernel_size]
+            if operation.type in {'Conv'}:
+                conv_weight_config = base_quant_config.input_quantization_config[1]
+                conv_weight_config.quant_max = int(pow(2, self._num_of_bits - 1))
+                conv_weight_config.quant_min = - int(pow(2, self._num_of_bits - 1) - 1)
+                conv_weight_config.policy = QuantizationPolicy(
+                    QuantizationProperty.SYMMETRICAL +
+                    QuantizationProperty.LINEAR +
+                    QuantizationProperty.PER_CHANNEL
+                )
+                base_quant_config.input_quantization_config[1] = \
+                    ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
+                        convert_from = conv_weight_config,
+                        offsets = None, scales  = None, channel_axis = 0
+                    )
+                base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
+            # first parameter must exits, for gemm layer it will be gemm_weight
+            # layout: [in_dim, out_dim]
+            else:
+                for index, input_var in enumerate(operation.inputs):
+                    if input_var.is_parameter:
+                        matmul_weight_config = base_quant_config.input_quantization_config[index]
+                        matmul_weight_config.quant_max = int(pow(2, self._num_of_bits - 1))
+                        matmul_weight_config.quant_min = - int(pow(2, self._num_of_bits - 1) - 1)
+                        matmul_weight_config.policy = QuantizationPolicy(
+                            QuantizationProperty.SYMMETRICAL +
+                            QuantizationProperty.LINEAR +
+                            QuantizationProperty.PER_CHANNEL
+                        )
+                        base_quant_config.input_quantization_config[index] = \
+                            ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
+                                convert_from = matmul_weight_config,
+                                offsets = None, scales  = None, channel_axis = 1
+                            )
+                        base_quant_config.input_quantization_config[index].observer_algorithm = 'Minmax'
+            # if operation has bias
+            if operation.type == 'Conv' and operation.num_of_input > 2:
+                bias_config = base_quant_config.input_quantization_config[-1]
+                bias_config.policy = QuantizationPolicy(
+                    QuantizationProperty.SYMMETRICAL +
+                    QuantizationProperty.LINEAR +
+                    QuantizationProperty.PER_CHANNEL
+                )
+                bias_config.num_of_bits = 32
+                bias_config.quant_max = int(pow(2, bias_config.num_of_bits - 1)) - 1
+                bias_config.quant_min = - int(pow(2, bias_config.num_of_bits - 1)) + 1
+                bias_config.state = QuantizationStates.PASSIVE_INIT
+                base_quant_config.input_quantization_config[-1] = \
+                    ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
+                        convert_from = bias_config, offsets = None,
+                        scales = None, channel_axis = 0
+                    )
+                base_quant_config.input_quantization_config[-1].observer_algorithm = 'Minmax'
+
+        if operation.type in PASSIVE_OPERATIONS:
+            # Those op are not active op.
+            base_quant_config.is_active_quant_op = False
+        return base_quant_config
+
+    @ property
+    def target_platform(self) -> TargetPlatform:
+        return TargetPlatform.ORT_OOS_INT8
+
+    @ property
+    def default_platform(self) -> TargetPlatform:
+        return TargetPlatform.FP32
+
+    @ property
+    def quant_operation_types(self) -> set:
+        return {
+            'Conv', 'GlobalAveragePool', 'AveragePool',
+            'Relu', 'Add', 'Clip',
+            'MatMul'
+        }
+
+    @ property
+    def quantize_policy(self) -> QuantizationPolicy:
+        return QuantizationPolicy(
+            QuantizationProperty.ASYMMETRICAL +
+            QuantizationProperty.LINEAR +
+            QuantizationProperty.PER_TENSOR
+        )
+
+    @ property
+    def rounding_policy(self) -> RoundingPolicy:
+        return RoundingPolicy.ROUND_HALF_EVEN

--- a/ppq/quantization/quantizer/__init__.py
+++ b/ppq/quantization/quantizer/__init__.py
@@ -5,3 +5,4 @@ from .NXPQuantizer import NXP_Quantizer
 from .PPLQuantizer import (PPLCUDA_INT4_Quantizer,
                            PPLCUDAMixPrecisionQuantizer, PPLCUDAQuantizer)
 from .TRTQuantizer import TensorRTQuantizer
+from .ORTQuantizer import ORT_PerTensorQuantizer, ORT_PerChannelQuantizer

--- a/ppq/scheduler/dispatchers.py
+++ b/ppq/scheduler/dispatchers.py
@@ -187,7 +187,7 @@ class ConservativeDispatcher(GraphDispatcher):
             'Conv', 'ConvTranspose', 'Gemm', 'Relu', 'PRelu', 'Clip', 'Pad',
             'Resize', 'MaxPool', 'AveragePool', 'GlobalMaxPool', 'GlobalAveragePool',
             'Mul', 'Add', 'Max', 'Sub', 'Div', 'LeakyRelu', 'Split', 'Concat',
-            'Reshape', 'Transpose', 'Slice', 'Flatten'}
+            'Reshape', 'Transpose', 'Slice', 'Flatten', 'MatMul'}
 
         recivers, generators = SOI_receivers(graph), SOI_generators(graph)
         search_engine, SOI_opeartions = SearchableGraph(graph), set(recivers)


### PR DESCRIPTION
This PR adds an MVP implementation of quantized ONNX model exporter with operator oriented style (OOS). It supports QLinear ops including `QLinearConv`, `QLinearAdd`, `QLinearMul`, `QLinearMatMul`, `QLinearGlobalAveragePool` and `QLinearAveragePool`. The elimination(fusion) of `Clip` and `Relu` is also supported. More ops might be added in the future.

This PR also implements two ORT quantizers (per-tensor and per-channel). ORTQuantizer + ORTExporter combination has been tested on ResNet18, ResNet50 and MobileNet V2 (flatten version), with a very small calibration dataset(~8) on CPU. The steps are:

1. Fix a backbone
2. Fix a quantizer (ORT per-channel or ORT per-tensor)
3. Do calibration with the same dataset, export with both `ONNXRUNTIMExporter` and `ORTOOSExporter`, get model A and model B
4. Feed random inputs, compare outputs of model A and model B, evaluate with cosine similarity and euclidean distance.

More tests might be done (I don't know very well about PPQ test).

Models are available [here](https://www.jianguoyun.com/p/DYeeWxwQjtGgChijvqwE). Noting to test `MatMul`, `GEMM ` in origin models has been replaced.