### PR TITLE
Core Update to 0.6.4

### DIFF
--- a/ppq/IR/morph.py
+++ b/ppq/IR/morph.py
@@ -141,7 +141,6 @@ class GraphFormatter(GraphCommandProcesser):
             self.__add_constant_input(slice, convert_any_to_torch_tensor(ends))
             self.__add_constant_input(slice, convert_any_to_torch_tensor(axes))
             
-
     def format_pad(self) -> None:
         """
             对于不同的模型格式, pad 算子将有两种不同的输入格式：
@@ -515,6 +514,30 @@ class GraphMerger(GraphCommandProcesser):
             self.graph.append_variable(weight_var)
             self.graph.append_variable(bias_var)
 
+
+class GraphDecomposer(GraphCommandProcesser):
+    """
+    Since PPQ 0.6.4, GraphDecomposer is introduced to split some complex operations
+        For example, Gemm can be split with Matmul with Bias add
+        Gru can be split with Matmul, Sigmoid, Tanh
+
+    Operation decomposition is required for quantize complex operations, which can not be
+        correctly described by input & output tensor quant configurations.
+    By spliting operation into a series lower operations, we can have more quant configurations to
+        control its quantization logic
+    """
+    
+    def process(self, command: GraphCommand) -> Any:
+        return super().process(command)
+    
+    def _acceptable_command_types(self) -> List[GraphCommandType]:
+        return super()._acceptable_command_types
+
+    def decompose_gemm():
+        pass
+
+    def decompose_gru():
+        pass
 
 class GraphDeviceSwitcher(GraphCommandProcesser):
     """

--- a/ppq/IR/quantize.py
+++ b/ppq/IR/quantize.py
@@ -125,7 +125,8 @@ class QuantableOperation(Operation):
     @ property
     def config_with_variable(self) -> List[Tuple[TensorQuantizationConfig, Variable]]:
         """
-        Just a helper function.
+        Just a helper function,
+            This function will list all related config and variable with current operation.
 
         Returns:
             List[Tuple[TensorQuantizationConfig, Variable]]: [description]

--- a/ppq/api/interface.py
+++ b/ppq/api/interface.py
@@ -65,8 +65,9 @@ EXPORTERS = {
     TargetPlatform.EXTENSION:     ExtensionExporter,
     # TargetPlatform.ORT_OOS_INT8:  ONNXRUNTIMExporter,
     TargetPlatform.ORT_OOS_INT8:  ORTOOSExporter,
-    TargetPlatform.METAX_INT8_C:  ONNXRUNTIMExporter,
-    TargetPlatform.METAX_INT8_T:  ONNXRUNTIMExporter,
+    TargetPlatform.METAX_INT8_C:  MetaxExporter,
+    TargetPlatform.METAX_INT8_T:  MetaxExporter,
+    TargetPlatform.TRT_INT8:      TensorRTExporter,
 }
 
 # 为你的导出模型取一个好听的后缀名

--- a/ppq/api/setting.py
+++ b/ppq/api/setting.py
@@ -329,6 +329,13 @@ class BlockwiseReconstructionSetting():
         self.scale_multiplier   = 2.0
 
 
+class WeightSplitSetting():
+    def __init__(self) -> None:
+        # computing layers which are intended to be splited
+        self.interested_layers = []
+        # the split will take effect only if loss decreases to this threshold of original loss
+        self.loss_reduce_thre  = 0.8
+
 
 class DispatchingTable():
     def __init__(self) -> None:
@@ -374,6 +381,9 @@ class QuantizationSetting():
         self.equalization                    = False
         self.equalization_setting            = EqualizationSetting()
         
+        self.weight_split                    = False
+        self.weight_split_setting            = WeightSplitSetting()
+
         # OCS channel split configuration
         self.channel_split                   = False
         self.channel_split_setting           = ChannelSplitSetting()

--- a/ppq/core/config.py
+++ b/ppq/core/config.py
@@ -1,15 +1,24 @@
+# 是否启动 cuda kernel 加速计算
 USING_CUDA_KERNEL = True
 if USING_CUDA_KERNEL:
     import os
+    # 这玩意我也不知道是干嘛的，但是 cuda 报错了它就总是让我设置这个为 1
     os.environ['CUDA_LAUNCH_BLOCKING'] = '0'
 
+# 开启 PPQ 调试模式，将打印所有量化点插入信息
 PPQ_DEBUG = False
 
+# PPQ 的名字
 PPQ_NAME = 'PPL Quantization Tool'
 
-PPQ_VERSION = '0.6.3'
+# PPQ 的版本号
+PPQ_VERSION = '0.6.4'
 
+# 导出图时是否导出权重（仅影响 Native 格式导出）
 DUMP_VALUE = True
 
+# 导出图时，是否导出 Device Switcher
 EXPORT_DEVICE_SWITCHER = False
+
+# 导出图时，是否导出调度信息
 EXPORT_PPQ_INTERNAL_INFO = False

--- a/ppq/core/data.py
+++ b/ppq/core/data.py
@@ -130,6 +130,9 @@ class TensorMeta:
                 A int list contains size of each dimensions.
             tensor_name (str, optional): Not yet used.
         """
+        if not isinstance(dtype, DataType):
+            raise TypeError(f'Can not create Tensor Meta with dtype {type(dtype)}, '
+                            'only ppq.core.DataType instance is acceptable here.')
         self.dtype = dtype
         self.shape = shape
         self.name  = tensor_name

--- a/ppq/core/ffi.py
+++ b/ppq/core/ffi.py
@@ -88,13 +88,14 @@ class CUDA:
         scales: torch.Tensor,
         offsets: torch.Tensor,
         dy: torch.Tensor,
+        grad_factor: float,
         minimum: int,
         maximum: int
     ) -> torch.Tensor:
         if not tensor.is_contiguous(): tensor = tensor.contiguous()
         return __CUDA_EXTENTION__.QuantizeTensor_LT_B(
             tensor, quantized, scales, offsets, 
-            dy, minimum, maximum
+            dy, grad_factor, minimum, maximum
         )
 
     @ staticmethod
@@ -104,6 +105,7 @@ class CUDA:
         scales: torch.Tensor,
         offsets: torch.Tensor,
         dy: torch.Tensor,
+        grad_factor: float,
         minimum: int,
         maximum: int,
         channel_axis: int,
@@ -111,7 +113,7 @@ class CUDA:
         if not tensor.is_contiguous(): tensor = tensor.contiguous()
         return __CUDA_EXTENTION__.QuantizeTensor_LC_B(
             tensor, quantized, scales, offsets, 
-            dy, minimum, maximum, channel_axis
+            dy, grad_factor, minimum, maximum, channel_axis
         )
 
     @ staticmethod

--- a/ppq/core/quant.py
+++ b/ppq/core/quant.py
@@ -72,9 +72,7 @@ class TargetPlatform(Enum):
     METAX_INT8_C = 701 # channel wise
     METAX_INT8_T = 702 # tensor wise
 
-    ACADEMIC_INT8 = 801
-    ACADEMIC_INT4 = 802
-    ACADEMIC_MIX  = 803
+    HEXAGON_INT8 = 801
 
     FP32 = 0
     # SHAPE-OR-INDEX related operation
@@ -90,6 +88,10 @@ class TargetPlatform(Enum):
     ONNXRUNTIME   = -7
     # THIS IS A DUUMY PLATFORM JUST FOR CREATING YOUR OWN EXTENSTION.
     EXTENSION     = -10086
+    
+    ACADEMIC_INT8 = 10081
+    ACADEMIC_INT4 = 10082
+    ACADEMIC_MIX  = 10083
     
     @ classmethod
     def is_quantized_platform(cls, platform) -> bool:
@@ -508,12 +510,12 @@ class TensorQuantizationConfig(Serializable):
         })
 
     @ property
-    def scale(self) -> Any:
+    def scale(self) -> torch.Tensor:
         if self.dominated_by == self: return self._scale
         else: return self.dominated_by.scale
 
     @ property
-    def offset(self) -> Any:
+    def offset(self) -> torch.Tensor:
         if self.dominated_by == self: return self._offset
         else: return self.dominated_by.offset
 

--- a/ppq/csrc/cuda/linear.h
+++ b/ppq/csrc/cuda/linear.h
@@ -12,10 +12,11 @@ Tensor QuantizeTensor_LC(
 
 std::vector<Tensor> QuantizeTensor_LT_B(
     const Tensor &value, const Tensor &quantized, 
-    const Tensor &scales, const Tensor &offsets, const Tensor &grad_y, 
-    const int clip_min, const int clip_max);
+    const Tensor &scales, const Tensor &offsets, const Tensor &grad_y,
+    const float grad_factor, const int clip_min, const int clip_max);
 
 std::vector<Tensor> QuantizeTensor_LC_B(
     const Tensor &value, const Tensor &quantized, 
     const Tensor &scales, const Tensor &offsets, const Tensor &grad_y, 
-    const int clip_min, const int clip_max, const int channel_axis);
+    const float grad_factor, const int clip_min, const int clip_max, 
+    const int channel_axis);

--- a/ppq/csrc/cuda/sort.cu
+++ b/ppq/csrc/cuda/sort.cu
@@ -40,7 +40,7 @@ static void _cuda_order_preserving_observe(
 }
 
 __host__ Tensor Quantile_T(const Tensor &source, const float q){
-    CheckTensor(source, at::kFloat, "Value(FP32)");
+    CheckTensor(source, at::kFloat, "Value(Expect to be FP32)");
     const int64_t num_of_elements = NUM_OF_ELEMENT(source);
     
     Tensor dest = at::empty({2}, source.options());
@@ -102,8 +102,8 @@ __host__ void Histogram_T(
      * Say we have a float value f, and a float value hist_scale
      * We will select hist_bin = floor(f / hist_scale)
      */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(hist, at::kInt, "Histogram(INT32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(hist, at::kInt, "Histogram(Expect to be INT32)");
 
     _Histogram_T<<<NUM_OF_BLOCK(NUM_OF_ELEMENT(value)), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
         NUM_OF_ELEMENT(value), NUM_OF_ELEMENT(hist), PTR<float>(value),
@@ -145,8 +145,8 @@ __host__ void Histogram_C(
      * Say we have a float value f, and a float value hist_scale
      * We will select hist_bin = floor(f / hist_scale)
      */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(hist, at::kInt, "Histogram(INT32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(hist, at::kInt, "Histogram(Expect to be INT32)");
 
     int element_per_channel = 1;
     const int num_of_channel = value.sizes()[channel_axis];

--- a/ppq/csrc/cuda/train.cu
+++ b/ppq/csrc/cuda/train.cu
@@ -57,9 +57,9 @@ __host__ Tensor TensorClip_C(
 
     This function will clip tensor value inplace.
      */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(reference, at::kFloat, "Reference(FP32)");
-    CheckTensor(limit, at::kFloat, "Limit(FP32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(reference, at::kFloat, "Reference(Expect to be FP32)");
+    CheckTensor(limit, at::kFloat, "Limit(Expect to be FP32)");
 
     int element_per_channel = 1;
     const int num_of_channel = value.sizes()[channel_axis];
@@ -98,9 +98,9 @@ __host__ Tensor TensorClip_T(
 
     This function will clip tensor value inplace.
     */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(reference, at::kFloat, "Reference(FP32)");
-    CheckTensor(limit, at::kFloat, "Limit(FP32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(reference, at::kFloat, "Reference(Expect to be FP32)");
+    CheckTensor(limit, at::kFloat, "Limit(Expect to be FP32)");
 
     Tensor out = at::empty_like(value);
     _TensorClip_T<<<NUM_OF_BLOCK(NUM_OF_ELEMENT(value)), 
@@ -137,7 +137,7 @@ __global__ void _RoundingLoss_LT(
         diff_sum += diff;
     }
     float diff_reduced = BlockReduceSum<float>(diff_sum);
-    if(threadIdx.x == 0) atomicAdd(out, diff_reduced / sqrt((float)num_of_element));
+    if(threadIdx.x == 0) atomicAdd(out, diff_reduced / sqrt(num_of_element));
 }
 
 __host__ Tensor RoundingLoss_LT(
@@ -153,9 +153,9 @@ __host__ Tensor RoundingLoss_LT(
         If one value inside R is clipped by quant function, 
             then it contributes nothing to R.
     */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(scale, at::kFloat, "Scale(FP32)");
-    CheckTensor(offset, at::kFloat, "Offset(FP32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(scale, at::kFloat, "Scale(Expect to be FP32)");
+    CheckTensor(offset, at::kFloat, "Offset(Expect to be FP32)");
 
     Tensor loss = at::zeros({1}, value.options());
     _RoundingLoss_LT<<<NUM_OF_BLOCK(NUM_OF_ELEMENT(value)), 
@@ -189,7 +189,7 @@ __global__ void _RoundingLoss_LT_B(
         // if value has been clipped, set grad = 0
         if (v > s * (clip_max - o)) grad = 0;
         if (v < s * (clip_min - o)) grad = 0;
-        dx[iter] = grad / sqrt((float)num_of_element);
+        dx[iter] = grad / sqrt(num_of_element);
     }
 }
 
@@ -202,9 +202,9 @@ __host__ Tensor RoundingLoss_LT_B(
     /*
         Compute grad through rounding loss.
     */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(scale, at::kFloat, "Scale(FP32)");
-    CheckTensor(offset, at::kFloat, "Offset(FP32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(scale, at::kFloat, "Scale(Expect to be FP32)");
+    CheckTensor(offset, at::kFloat, "Offset(Expect to be FP32)");
 
     Tensor grad_v = at::zeros_like(value);
     _RoundingLoss_LT_B<<<NUM_OF_BLOCK(NUM_OF_ELEMENT(value)), 
@@ -243,7 +243,7 @@ __global__ void _RoundingLoss_LC(
         diff_sum += diff;
     }
     float diff_reduced = BlockReduceSum<float>(diff_sum);
-    if(threadIdx.x == 0) atomicAdd(out, diff_reduced / sqrt((float)num_of_element));
+    if(threadIdx.x == 0) atomicAdd(out, diff_reduced / sqrt(num_of_element));
 }
 
 __host__ Tensor RoundingLoss_LC(
@@ -259,9 +259,9 @@ __host__ Tensor RoundingLoss_LC(
         If one value inside R is clipped by quant function, 
             then it contributes nothing to R.
     */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(scale, at::kFloat, "Scale(FP32)");
-    CheckTensor(offset, at::kFloat, "Offset(FP32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(scale, at::kFloat, "Scale(Expect to be FP32)");
+    CheckTensor(offset, at::kFloat, "Offset(Expect to be FP32)");
 
     int element_per_channel = 1;
     const int num_of_channel = value.sizes()[channel_axis];
@@ -303,7 +303,7 @@ __global__ void _RoundingLoss_LC_B(
         // if value has been clipped, set grad = 0
         if (v > scale[c] * (clip_max - offset[c])) grad = 0;
         if (v < scale[c] * (clip_min - offset[c])) grad = 0;
-        dx[iter] = grad / sqrt((float)num_of_element);
+        dx[iter] = grad / sqrt(num_of_element);
     }
 }
 
@@ -316,9 +316,9 @@ __host__ Tensor RoundingLoss_LC_B(
     /*
         Compute grad through rounding loss.
     */
-    CheckTensor(value, at::kFloat, "Value(FP32)");
-    CheckTensor(scale, at::kFloat, "Scale(FP32)");
-    CheckTensor(offset, at::kFloat, "Offset(FP32)");
+    CheckTensor(value, at::kFloat, "Value(Expect to be FP32)");
+    CheckTensor(scale, at::kFloat, "Scale(Expect to be FP32)");
+    CheckTensor(offset, at::kFloat, "Offset(Expect to be FP32)");
 
     int element_per_channel = 1;
     const int num_of_channel = value.sizes()[channel_axis];

--- a/ppq/executor/base.py
+++ b/ppq/executor/base.py
@@ -51,7 +51,7 @@ class RuntimeHook(metaclass=ABCMeta):
     def __init__(self, operation: Operation, operation_meta: OperationMeta = None) -> None:
         self._hook_to = operation
         self._op_meta = operation_meta
-    
+
     def pre_forward_hook(self, inputs: list, **kwargs) -> list:
         """
             user-customized pre-processing procedure of input data

--- a/ppq/parser/__init__.py
+++ b/ppq/parser/__init__.py
@@ -2,7 +2,7 @@ from ppq.core import NetworkFramework, TargetPlatform, ppq_warning
 from ppq.IR import BaseGraph, GraphBuilder, GraphExporter
 
 from .caffe_exporter import (CaffeExporter, PPLDSPCaffeExporter,
-                             SNPECaffeExporter, PPLDSPTICaffeExporter)
+                             PPLDSPTICaffeExporter, SNPECaffeExporter)
 from .caffe_parser import CaffeParser
 from .extension import ExtensionExporter
 from .native import NativeExporter, NativeImporter
@@ -12,51 +12,5 @@ from .onnx_parser import OnnxParser
 from .onnxruntime_exporter import ONNXRUNTIMExporter
 from .onnxruntime_oos_exporter import ORTOOSExporter
 from .ppl import PPLBackendExporter
-
-'''
-PARSERS = {
-    NetworkFramework.ONNX: OnnxParser,
-    NetworkFramework.CAFFE: CaffeParser,
-    NetworkFramework.NATIVE: NativeImporter
-}
-
-EXPORTERS = {
-    TargetPlatform.PPL_DSP_INT8:  PPLDSPCaffeExporter,
-    TargetPlatform.PPL_CUDA_INT8: PPLBackendExporter,
-    TargetPlatform.SNPE_INT8:     SNPECaffeExporter,
-    TargetPlatform.NXP_INT8:      NxpExporter,
-    TargetPlatform.ONNX:          OnnxExporter,
-    TargetPlatform.ONNXRUNTIME:   ONNXRUNTIMExporter,
-    TargetPlatform.CAFFE:         CaffeExporter,
-    TargetPlatform.NATIVE:        NativeExporter,
-    TargetPlatform.EXTENSION:     ExtensionExporter,
-    # TargetPlatform.ORT_OOS_INT8:  ONNXRUNTIMExporter,
-    TargetPlatform.ORT_OOS_INT8:  ORTOOSExporter,
-}
-try:
-    from .tensorRT import TensorRTExporter
-    EXPORTERS[TargetPlatform.TRT_INT8] = TensorRTExporter
-except ImportError as e:
-    ppq_warning('Since PPQ can not found a tensorRT installation, tensorRT export has been deactived.')
-
-
-def load_graph(file_path: str, from_framework: NetworkFramework=NetworkFramework.ONNX, **kwargs) -> BaseGraph:
-    if from_framework not in PARSERS:
-        raise KeyError(f'Requiring framework {from_framework} does not support parsing now.')
-    parser = PARSERS[from_framework]()
-    assert isinstance(parser, GraphBuilder), 'Unexpected Parser found.'
-    if from_framework == NetworkFramework.CAFFE:
-        assert 'caffemodel_path' in kwargs, ('parameter "caffemodel_path" is required here for loading caffe model from file, '
-                                             'however it is missing from your invoking.')
-        graph = parser.build(prototxt_path=file_path, caffemodel_path=kwargs['caffemodel_path'])
-    else:
-        graph = parser.build(file_path)
-    return graph
-
-def dump_graph_to_file(file_path: str, config_path: str, target_platform: TargetPlatform, graph: BaseGraph, **kwargs) -> None:
-    if target_platform not in EXPORTERS:
-        raise KeyError(f'Requiring framework {target_platform} does not support export now.')
-    exporter = EXPORTERS[target_platform]()
-    assert isinstance(exporter, GraphExporter), 'Unexpected Exporter found.'
-    exporter.export(file_path=file_path, config_path=config_path, graph=graph, **kwargs)
-'''
+from .tensorRT import TensorRTExporter
+from .matex_exporter import MetaxExporter

--- a/ppq/parser/matex_exporter.py
+++ b/ppq/parser/matex_exporter.py
@@ -1,0 +1,378 @@
+from ast import Continue
+from typing import Dict, List, Tuple
+
+import onnx
+import torch
+from onnx import helper
+from ppq.core import (COMPELING_OP_TYPES, EXPORT_DEVICE_SWITCHER, PPQ_NAME,
+                      ChannelwiseTensorQuantizationConfig, OperationMeta,
+                      QuantizationProperty, QuantizationStates, TensorMeta,
+                      TensorQuantizationConfig, convert_any_to_torch_tensor)
+from ppq.IR import (BaseGraph, Operation, QuantableOperation,
+                    QuantableVariable, Variable)
+from ppq.IR.base.command import GraphCommand, GraphCommandType
+from ppq.IR.morph import GraphDeviceSwitcher, GraphFormatter
+from ppq.utils.round import ppq_tensor_round
+
+from .onnx_exporter import OnnxExporter
+
+# legacy exporter since ppq 0.6.4
+# use onnxruntime exporter instead.
+class MetaxExporter(OnnxExporter):
+    """ONNXRUNTIME int8 QDQ format exporter, no further actions should be applied to the graph because we will modify the graph
+    in-place, and the modified graph can't be executed. We remove Clip and Relu ops(fuse into computing op) here when asym quantization
+    for activation is applied, and following the official implementation, when an variable has multiple outputs, we assume the same
+    quantization scales and offset. For parameters, we pre-quantize the value and only insert DequantizeLinear op, both per-layer/per-channel
+    and asym/sym quantizations are supported for export, the exported onnx model is tested to align with PPQ monitor when CUDAExecutionProvider
+    is applied in onnxruntime-gpu >= 1.8.1, i.e., to run the model correctly if you have gpu and onnxruntime-gpu version installed
+    
+    X     W      b             X        quant(W)   quant(b)
+    \     |     /               \         |          /
+     \    |    /                quant    dequant  dequant
+        Conv             ->       \       |        /
+          |                      dequant  |       / 
+          |                         \     |      / 
+                                         Conv
+                                          |
+                                        quant
+                                          |
+                                        dequant
+                                          |
+    ```
+    import onnxruntime as ort
+    sess_options = ort.SessionOptions()
+    sess = ort.InferenceSession(file_path, sess_options, providers=['CUDAExecutionProvider'])
+    res = sess.run(None, {sess.get_inputs()[0].name : dummy_input.cpu().numpy()})
+    ```
+    """
+
+    def __init__(self, removed_activation_types: List[str] = ['Relu', 'Clip']) -> None:
+        super().__init__()
+        self.removed_activation_types = removed_activation_types
+
+    def inplace_quantization(self, var: QuantableVariable, is_bias: bool) -> Tuple[torch.Tensor, torch.Tensor, int]:
+        config = var.dest_op_configs[0]
+        assert isinstance(config, TensorQuantizationConfig)
+        tensor = var.value
+        scale, offset = config.scale, config.offset
+        axis = 1
+        if config.policy.has_property(QuantizationProperty.PER_TENSOR):
+            tensor = ppq_tensor_round((tensor / scale), config.rounding) + offset
+            tensor = torch.clamp(tensor, config.quant_min, config.quant_max)
+        else:
+            assert isinstance(config, ChannelwiseTensorQuantizationConfig)
+            shape = [1 if axis != config.channel_axis else -1 for axis in range(tensor.ndim)]
+            scale, offset = scale.view(shape), offset.view(shape)
+            tensor = ppq_tensor_round((tensor / scale), config.rounding) + offset
+            tensor = torch.clamp(tensor, config.quant_min, config.quant_max)
+            axis = config.channel_axis
+        if is_bias:
+            var.value = tensor.type(torch.int32)
+        elif config.policy.has_property(QuantizationProperty.ASYMMETRICAL):
+            var.value = tensor.type(torch.uint8)
+        else:
+            var.value = tensor.type(torch.int8)
+        return (convert_any_to_torch_tensor(config.scale, dtype=torch.float32), 
+            convert_any_to_torch_tensor(config.offset, dtype=var.value.dtype), axis)
+
+    def insert_quant_dequant_on_var(
+        self, graph: BaseGraph, var: QuantableVariable,
+        config: TensorQuantizationConfig=None, single_branch: bool=False,
+        dest_op: Operation=None) -> None:
+        """insert quant and dequant op on common quantable variables, by default a pair of quant
+        and dequant ops will be inserted on var, i.e., all destinations of original var will be
+        replaced by output of dequant op, but you can also insert on single var--dest_op branch
+        by setting single_branch=True, in this case you should give the desired dest_op as the
+        destination op of dequant op 
+        Args:
+            graph (BaseGraph): PPQ IR graph.
+            var (Variable): quantable variables, parameters assumed.
+            config (TensorQuantizationConfig, optional): quantization config. Defaults to None.
+            single_branch (bool, optional): whether to insert on var(replace all destinations)
+                                            or insert on just single branch. Defaults to False.
+            dest_op (Operation, optional): shouldn't be None when single_branch is True. Defaults to None.
+        """
+        if config is None:
+            configs = [cfg for cfg in [var.source_op_config] + var.dest_op_configs if cfg is not None]
+            config = configs[0]
+
+        offset_dtype = torch.int8 
+        if config.policy.has_property(QuantizationProperty.ASYMMETRICAL): offset_dtype = torch.uint8 
+        scale  = convert_any_to_torch_tensor(config.scale, dtype=torch.float32)
+        offset = convert_any_to_torch_tensor(config.offset, dtype=offset_dtype)
+        
+        qt_svar = Variable(name=var.name + '_qt_scale', value=scale.clone(), is_parameter=True)
+        qt_zvar = Variable(name=var.name + '_qt_zeropoint', value=offset.clone(), is_parameter=True)
+        dq_svar = Variable(name=var.name + '_dq_scale', value=scale.clone(), is_parameter=True)
+        dq_zvar = Variable(name=var.name + '_dq_zeropoint', value=offset.clone(), is_parameter=True)
+        
+        qt_op = Operation(name=var.name + '_QuantizeLinear', op_type='QuantizeLinear', attributes={})
+        dq_op = Operation(name=var.name + '_DequantizeLinear', op_type='DequantizeLinear', attributes={})
+        
+        if single_branch:
+            upstream_op, downstream_op = var.source_op, dest_op
+            graph.insert_op_between_ops(qt_op, up_op=upstream_op, down_op=downstream_op)
+            graph.insert_op_between_ops(dq_op, up_op=qt_op, down_op=downstream_op)
+
+        if not single_branch:
+            graph.insert_op_on_var(dq_op, var=var.name)
+            graph.insert_op_on_var(qt_op, var=var.name)
+
+        qt_op.inputs.extend([qt_svar, qt_zvar])
+        dq_op.inputs.extend([dq_svar, dq_zvar])
+
+        qt_svar.dest_ops.append(qt_op)
+        qt_zvar.dest_ops.append(qt_op)
+        dq_svar.dest_ops.append(dq_op)
+        dq_zvar.dest_ops.append(dq_op)
+
+        graph.append_variable(qt_svar)
+        graph.append_variable(qt_zvar)
+        graph.append_variable(dq_svar)
+        graph.append_variable(dq_zvar)
+
+
+    def insert_dequant_param(self, graph: BaseGraph, var: Variable, is_bias: bool) -> None:
+        # apply inplace quantization for parameters and only insert dequant op
+        # on pre-quant var
+        scale, offset, axis = self.inplace_quantization(var, is_bias)
+        dequant_op = Operation(name=var.name + '_DequantizeLinear', op_type='DequantizeLinear', attributes={'axis':axis})
+        graph.insert_op_on_var(dequant_op, var.name)
+        scale = Variable(name=var.name + '_scale', value=scale, is_parameter=True, dest_ops=[dequant_op])
+        offset = Variable(name=var.name + '_zero_point', value=offset, is_parameter=True, dest_ops=[dequant_op])
+        graph.append_variable(scale)
+        graph.append_variable(offset)
+        dequant_op.inputs.extend([scale, offset])
+
+    def correct_param_meta(self, graph: BaseGraph) -> None:
+        # correct parameter meta data
+        for var in graph.variables.values():
+            if var.is_parameter:
+                for op in var.dest_ops:
+                    if op.meta_data is None:
+                        op.meta_data = OperationMeta([TensorMeta(None, None, v.name) for v in 
+                            op.inputs], [TensorMeta(None, None, v.name) for v in 
+                            op.outputs], op.name, op.type, -1)
+
+                    if torch.is_tensor(var.value):
+                        op.meta_data.input_metas[op.inputs.index(var)] = \
+                            TensorMeta.parsing_from_torch_tensor(var.value, var.name)
+                    else:
+                        op.meta_data.input_metas[op.inputs.index(var)] = \
+                            TensorMeta.parsing_from_numpy_ndarray(var.value, var.name)
+
+        # add variable meta info in topo order
+        for op in graph.topological_sort():
+            if op.type == 'QuantizeLinear' and op.inputs[0].source_op is not None:
+                input_var = op.inputs[0]
+                op.meta_data.input_metas[0] = input_var.meta
+                op.meta_data.output_metas[0].shape = input_var.meta.shape
+                op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[2].dtype
+                dequant_op = op.outputs[0].dest_ops[0]
+                dequant_op.meta_data.input_metas[0] = op.meta_data.output_metas[0]
+                dequant_op.meta_data.output_metas[0].shape = input_var.meta.shape
+                dequant_op.meta_data.output_metas[0].dtype = dequant_op.meta_data.input_metas[1].dtype
+            # must be input
+            elif op.type == 'QuantizeLinear' and op.inputs[0].value is None:
+                var = op.outputs[0]
+                dest_op = var.dest_ops[0]
+                dest_idx = var.dest_idx[0]
+                meta = dest_op.meta_data.input_metas[dest_idx]
+                # meta can't be None itself because we have built TensorMeta 
+                # for every input when we correct param meta
+                while meta.shape is None or meta.dtype is None:
+                    assert isinstance(dest_op, Operation)
+                    var = dest_op.outputs[0]
+                    dest_op = var.dest_ops[0]
+                    dest_idx = var.dest_idx[0]
+                    meta = dest_op.meta_data.input_metas[dest_idx]
+
+                dequant_op = op.outputs[0].dest_ops[0]
+                dequant_op.meta_data.output_metas[0] = meta
+                dequant_op.meta_data.input_metas[0].shape = meta.shape
+                dequant_op.meta_data.input_metas[0].dtype = dequant_op.meta_data.input_metas[2].dtype
+                op.meta_data.input_metas[0] = meta
+                op.meta_data.output_metas[0].shape = meta.shape
+                op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[2].dtype
+            elif op.type == 'DequantizeLinear' and op.inputs[0].source_op is None:
+                op.meta_data.output_metas[0].shape = op.meta_data.input_metas[0].shape
+                op.meta_data.output_metas[0].dtype = op.meta_data.input_metas[1].dtype
+
+    def remove_activation(self, graph: BaseGraph, activation_ops: List[Operation]) -> None:
+        # Activation op can only be relu and clip,
+        # so it is safe to access op.inputs[0], op.outputs[0] as their input and output.
+        for op in activation_ops:
+            if not isinstance(op, QuantableOperation): continue
+            if len(graph.get_upstream_operations(op)) == 0: Continue
+
+            upstream_op = graph.get_upstream_operations(op)[0]
+            if not isinstance(upstream_op, QuantableOperation): continue
+            input_var, input_cfg = op.inputs[0], op.config.input_quantization_config[0]
+            if not input_cfg.policy.has_property(QuantizationProperty.ASYMMETRICAL): continue
+
+            # PATCH 20220304 Removing graph output op might cause error.
+            if op.outputs[0].name in graph.outputs:
+                graph.outputs.pop(op.outputs[0].name)
+                graph.outputs[input_var.name] = input_var
+
+            if op.type == 'Clip':
+                for var in op.inputs[1:]:
+                    var.dest_ops.clear()
+                    graph.delete_variable(var.name)
+                while len(op.inputs) > 1:
+                    op.inputs.pop()
+            graph.remove_operation(op)
+        formater = GraphFormatter(graph)
+        formater(GraphCommand(GraphCommandType.DELETE_ISOLATED))
+
+    def required_opsets(self) -> Dict[str, int]:
+        extra_domain_versions = [
+            ("ai.onnx", 13),
+            ("com.microsoft", 1),
+            ("com.microsoft.nchwc", 1),
+            ("ai.onnx.training", 1),
+            ("ai.onnx.preview.training", 1),
+            ("com.microsoft.experimental", 1),
+            ("ai.onnx.ml", 2)
+            ]
+        return dict(extra_domain_versions)
+
+    def transform_op(self, graph:BaseGraph) -> None:
+        # this func transform representation of certain op from opset 11 to 13
+        for op in graph.operations.values():
+            if op.type == 'ReduceSum' or op.type == 'Squeeze' or op.type == 'Unsqueeze':
+                axes = convert_any_to_torch_tensor(op.attributes.pop('axes'), dtype=torch.int64)
+                var = Variable(name=op.name+'_axes', value=axes, is_parameter=True, dest_ops=[op])
+                graph.append_variable(var)
+                op.inputs.append(var)
+                op.meta_data.input_metas.append(TensorMeta.parsing_from_torch_tensor(var.value, var.name))
+
+            elif op.type == 'Split':
+                split = convert_any_to_torch_tensor(op.attributes.pop('split'), dtype=torch.int64)
+                var = Variable(name=op.name+'_axes', value=split, is_parameter=True, dest_ops=[op])
+                graph.append_variable(var)
+                op.inputs.append(var)
+                op.meta_data.input_metas.append(TensorMeta.parsing_from_torch_tensor(var.value, var.name))
+
+    def collect_compel_pair(self, graph: BaseGraph) -> None:
+        # make sure settings of output of Add, Concat, Sub ops are applied to inputs as well
+        # this func should be called only for a supplemental method for coherent quantization
+        # setting for special ops
+        compel_ops, compel_pairs = [], []
+        for op in graph.operations.values():
+            if op.type in COMPELING_OP_TYPES and isinstance(op, QuantableOperation):
+                compel_ops.append(op)
+        for op in compel_ops:
+            assert isinstance(op, QuantableOperation)
+            for var in op.inputs:
+                assert isinstance(var, QuantableVariable)
+                if var.source_op_config is not None and \
+                    var.source_op_config.dominated_by != op.config.input_quantization_config[0].dominated_by:
+                    compel_pairs.append((var, op, op.config.input_quantization_config[0]))
+        return compel_pairs
+
+    def export(self, file_path: str, graph: BaseGraph, config_path: str = None) -> None:
+        # remove switchers.
+        if not EXPORT_DEVICE_SWITCHER:
+            processer = GraphDeviceSwitcher(graph)
+            processer.remove_switcher()
+
+        # if a valid config path is given, export quantization config to there.
+        if config_path is not None:
+            super().export_quantization_config(config_path, graph)
+
+        # collect compel var-op pair in advance to avoid graph change influence
+        compel_pairs = self.collect_compel_pair(graph)
+
+        # collect quantable vars, where we need to insert quant and dequant op
+        # note that we assume all quantization configs of the same variable maintained 
+        # by different ops are actually the same
+        quantable_vars,removed_activations = [], []
+        for var in graph.variables.values():
+            if isinstance(var, QuantableVariable):
+                configs = [var.source_op_config] + var.dest_op_configs
+                for cfg in configs:
+                    if cfg is not None and not QuantizationStates.can_export(cfg.state):
+                        raise AttributeError(f"quantization state of variable {var.name} is unexpected, \
+                        please check if you have finished the whole quantization process")
+                    elif cfg is not None and cfg.state not in {QuantizationStates.FP32, QuantizationStates.SOI}:
+                        quantable_vars.append(var)
+                        break
+
+        for var in quantable_vars:
+            assert isinstance(var, QuantableVariable)
+            # assume parameter var is used by only one op
+            if var.is_parameter:
+                if var.dest_ops[0].is_computing_op and var.dest_idx[0] > 1:
+                    self.insert_dequant_param(graph, var, True)
+                else:
+                    self.insert_dequant_param(graph, var, False)
+            elif not(var.source_op is not None and var.source_op.is_computing_op and\
+                len(var.dest_ops) == 1 and var.dest_ops[0].type in self.removed_activation_types):
+                self.insert_quant_dequant_on_var(graph, var)
+            else:
+                removed_activations.extend(var.dest_ops)
+
+        self.remove_activation(graph, removed_activations)
+
+        # insert another pair of quant and dequant ops for compel pairs
+        for (var, op, cfg) in compel_pairs:
+            assert isinstance(var, Variable)
+            # skip newly added ops
+            while op not in var.dest_ops:
+                assert var.dest_ops[0].type in {'QuantizeLinear', 'DequantizeLinear'}
+                var = var.dest_ops[0].outputs[0]
+            self.insert_quant_dequant_on_var(graph, var, cfg, True, op)
+
+        # collect meta info for parameters and newly-added variables
+        self.correct_param_meta(graph)
+        self.transform_op(graph)
+
+        name = graph._name
+        if not name: name = 'PPL Quantization Tool - Onnx Export'
+        
+        # Ready to export onnx graph defination.
+        _inputs, _outputs, _initilizers, _nodes = [], [], [], []
+        for operation in graph.topological_sort():
+            _nodes.append(super().export_operation(operation))
+
+        for variable in graph.variables.values():
+            tensor_proto = super().export_var(variable)
+            if variable.name in graph.inputs:
+                _inputs.append(tensor_proto)
+            if variable.name in graph.outputs:
+                _outputs.append(tensor_proto)
+            if variable.is_parameter:
+                _initilizers.append(tensor_proto)
+
+        graph_def = helper.make_graph(
+            name=name,
+            nodes=_nodes,
+            inputs=_inputs,
+            outputs=_outputs,
+            initializer=_initilizers,
+        )
+
+        extra_opsets = self.required_opsets()
+
+        if 'opsets' in graph._detail:
+            opsets = []
+            for opset in graph._detail['opsets']:
+                if opset['domain'] in extra_opsets or opset['domain'] == '':
+                    continue
+                op = onnx.OperatorSetIdProto()
+                op.domain = opset['domain']
+                op.version = opset['version']
+                opsets.append(op)
+
+        for key, value in extra_opsets.items():
+            op = onnx.OperatorSetIdProto()
+            op.domain = key
+            op.version = value
+            opsets.append(op)
+
+        onnx_model = helper.make_model(
+            graph_def, producer_name=PPQ_NAME, opset_imports=opsets)
+        onnx_model.ir_version = 7
+        # onnx.checker.check_model(onnx_model)
+        onnx.save(onnx_model, file_path)

--- a/ppq/parser/onnxruntime_oos_exporter.py
+++ b/ppq/parser/onnxruntime_oos_exporter.py
@@ -5,9 +5,10 @@ import onnx
 import torch
 from onnx import helper
 from ppq.core import (EXPORT_DEVICE_SWITCHER, ORT_MICROSOFT_CONTRIB_LINEAR_OPS,
-                      ORT_OOS_FUSE_START_OPS, PPQ_NAME, OperationMeta,
-                      QuantizationProperty, QuantizationStates, TensorMeta,
-                      TensorQuantizationConfig, convert_any_to_torch_tensor)
+                      ORT_OOS_FUSE_START_OPS, PPQ_NAME, DataType,
+                      OperationMeta, QuantizationProperty, QuantizationStates,
+                      TensorMeta, TensorQuantizationConfig,
+                      convert_any_to_torch_tensor)
 from ppq.IR import BaseGraph, Operation, QuantableVariable, Variable
 from ppq.IR.morph import GraphDeviceSwitcher
 from ppq.IR.quantize import QuantableOperation
@@ -529,7 +530,7 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
                 curr_meta_len = len(op.meta_data.input_metas)
                 expected_len = len(op.inputs)
                 for _ in range(expected_len - curr_meta_len):
-                    op.meta_data.input_metas.append(TensorMeta(None, None))
+                    op.meta_data.input_metas.append(TensorMeta(DataType.FP32, None))
             if op.type == "QLinearAdd":
                 # the second operand's index move from 1 to 3
                 op.meta_data.input_metas[3] = op.meta_data.input_metas[1]
@@ -540,8 +541,8 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
                 for op in var.dest_ops:
                     if op.meta_data is None:
                         op.meta_data = OperationMeta(
-                            [TensorMeta(None, None, v.name) for v in op.inputs],
-                            [TensorMeta(None, None, v.name) for v in op.outputs],
+                            [TensorMeta(DataType.FP32, None, v.name) for v in op.inputs],
+                            [TensorMeta(DataType.FP32, None, v.name) for v in op.outputs],
                             op.name,
                             op.type,
                             -1,
@@ -631,7 +632,7 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
                 and var.dest_ops[0].type in self.removed_activation_types
             ):
                 removed_activations.extend(var.dest_ops)
-        self.remove_activation(graph, removed_activations)
+        self.remove_activation_ops(graph, removed_activations)
 
         # Pass 2: insert QuantizeLinear & DequantizeLinear ops
         for var in quantable_vars:
@@ -703,7 +704,7 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
         self.correct_param_meta(graph)
 
         # Pass 5 transform other ops
-        self.transform_op(graph)
+        self.convert_operation_from_opset11_to_opset13(graph)
 
         name = graph._name
         if not name:
@@ -734,7 +735,7 @@ class ORTOOSExporter(ONNXRUNTIMExporter):
             value_info=_value_infos,
         )
 
-        extra_opsets = self.required_opsets()
+        extra_opsets = self.required_opsets
 
         if "opsets" in graph._detail:
             opsets = []

--- a/ppq/quantization/optim/__init__.py
+++ b/ppq/quantization/optim/__init__.py
@@ -4,7 +4,7 @@ from .base import (QuantizationOptimizationPass,
 from .calibration import RuntimeCalibrationPass, RuntimePerlayerCalibrationPass, PPLDSPTIReCalibrationPass
 from .equalization import LayerwiseEqualizationPass
 from .extension import ExtensionPass
-from .morph import (ChannelSplitPass, MatrixFactorizationPass,
+from .morph import (ChannelSplitPass, WeightSplitPass, MatrixFactorizationPass,
                     NXPResizeModeChangePass)
 from .parameters import ParameterQuantizePass, PassiveParameterQuantizePass
 from .refine import (QuantAlignmentPass, InplaceQuantizationSettingPass,

--- a/ppq/quantization/optim/morph.py
+++ b/ppq/quantization/optim/morph.py
@@ -1,19 +1,26 @@
 from math import ceil
-from typing import Iterable, List
+from typing import Callable, Iterable, List, Tuple, Union
 
+import numpy as np
 import torch
-from ppq.core import (QuantizationStates, TensorMeta, empty_ppq_cache,
-                      ppq_warning)
-from ppq.executor import BaseGraphExecutor
+from ppq.core import (NetworkFramework, OperationQuantizationConfig,
+                      QuantizationStates, TensorMeta, TensorQuantizationConfig,
+                      empty_ppq_cache, ppq_warning)
+from ppq.executor import BaseGraphExecutor, TorchExecutor
 from ppq.IR import BaseGraph, GraphCommandProcesser, Operation, Variable
+from ppq.IR.base.command import QuantizeOperationCommand
 from ppq.IR.morph import GraphReplacer
-from ppq.IR.quantize import QuantableOperation
+from ppq.IR.quantize import QuantableGraph, QuantableOperation
 from ppq.IR.search import Path, SearchableGraph
 from ppq.log import NaiveLogger
 from ppq.quantization.observer import TensorObserverFactroy
 from tqdm import tqdm
 
 from .base import QuantizationOptimizationPass
+from .calibration import RuntimeCalibrationPass
+from .parameters import ParameterQuantizePass, PassiveParameterQuantizePass
+from .refine import QuantAlignmentPass, QuantizeReducePass
+from .training import compute_loss
 
 logger = NaiveLogger.get_logger('PPQ')
 
@@ -188,6 +195,356 @@ class MatrixFactorizationPass(QuantizationOptimizationPass):
                 bias_var.dest_ops.append(splited)
                 splited.inputs.append(bias_var)
                 operation.inputs.remove(bias_var)
+
+
+class WeightSplitPass(QuantizationOptimizationPass):
+    """WeightSplitPass is similar to Outlier ChannelSplitPass below, both desgined for per-tensor quantization,
+    the difference is that ChannelSplitPass needs to find a counterpart computing operation right next to the 
+    desired computing layers so that no new operators will be added to graph. However, WeightSplitPass can operate
+    under any kind of situation, and the cost will be computing overhead for bringing in new quantization operators.
+
+       Conv    ==>   Conv_child_1  Conv_child_2
+                            \       / 
+                             \     /
+                               Add   
+                                |
+    
+        Use this pass when some very bad layer appears in precision analysis, i.e., the layer encountering a huge snr
+    error or reflecting poor cosine similarity.
+    """
+    def __init__(self,
+                interested_layers: List[str]=[],
+                loss_reduce_thre: float=0.80
+                ) -> None:
+        """Weight Split Pass
+
+        Args:
+            interested_layers (List[str], optional): layers which need split. Defaults to [].
+            loss_reduce_thre (float, optional): the split will take effect only if mse loss after split is less than
+                                                this threshold wrt. the original loss. Defaults to 0.80.
+        """
+        super().__init__('Weight Split Pass')
+        self.interested_layers = interested_layers
+        self.loss_reduce_thre  = loss_reduce_thre
+
+    def init_tri_op_graph(self, computing_op: QuantableOperation) -> BaseGraph:
+        # build tri-op subgraph for testing different split points
+        graph = BaseGraph(name='TempGraph', built_from=NetworkFramework.NATIVE)
+        input_var = Variable(name='Input', is_parameter=False)
+        
+        first_child_param_weight  = Variable(name=f'{computing_op.name}_first_child_weight', \
+                            value=computing_op.parameters[0].value, is_parameter=True)
+        first_child_output        = Variable(name=f'{computing_op.name}_first_child_output')
+
+        second_child_param_weight = Variable(name=f'{computing_op.name}_second_child_weight', \
+                            value=computing_op.parameters[0].value, is_parameter=True)
+        second_child_output       = Variable(name=f'{computing_op.name}_second_child_output')
+        
+        final_output = Variable(name='Output')
+
+        graph.append_variable(input_var)
+        graph.append_variable(first_child_param_weight)
+        graph.append_variable(first_child_output)
+        graph.append_variable(second_child_param_weight)
+        graph.append_variable(second_child_output)
+        graph.append_variable(final_output)
+
+        first_child = Operation(name=f'{computing_op.name}_first_child', op_type=computing_op.type, \
+            attributes=computing_op.attributes, inputs=[input_var, first_child_param_weight], outputs=[first_child_output])
+        
+        second_child = Operation(name=f'{computing_op.name}_second_child', op_type=computing_op.type, \
+            attributes=computing_op.attributes, inputs=[input_var, second_child_param_weight], outputs=[second_child_output])
+
+        add_receiver = Operation(name=f'{computing_op.name}_Add_Receiver', op_type='Add', attributes={}, \
+            inputs=[first_child_output, second_child_output], outputs=[final_output])
+
+        graph.append_operation(first_child)
+        graph.append_operation(second_child)
+        graph.append_operation(add_receiver)
+
+        input_var.dest_ops.extend([first_child, second_child])
+        first_child_param_weight.dest_ops.append(first_child)
+        first_child_output.source_op = first_child
+        first_child_output.dest_ops.append(add_receiver)
+        second_child_param_weight.dest_ops.append(second_child)
+        second_child_output.source_op = second_child
+        second_child_output.dest_ops.append(add_receiver)
+        final_output.source_op = add_receiver
+        
+        if len(computing_op.parameters) == 2:
+            first_bias = Variable(name=f'{computing_op.name}_first_child_bias', is_parameter=True, \
+                value=computing_op.parameters[1].value, dest_ops=[first_child])
+            second_bias = Variable(name=f'{computing_op.name}_second_child_bias', is_parameter=True, \
+                value=computing_op.parameters[1].value, dest_ops=[second_child])
+            first_child.inputs.append(first_bias)
+            second_child.inputs.append(second_bias)
+            graph.append_variable(first_bias)
+            graph.append_variable(second_bias)
+
+        graph.inputs['Input']  = input_var
+        graph.outputs['Output'] = final_output
+
+        return graph
+    
+    def quantize(self, computing_op: QuantableOperation, processer: GraphCommandProcesser) -> None:
+        graph = processer._graph
+        configs = {}
+        sample_cfg = computing_op.config.input_quantization_config[0]
+        # init configs
+        for op in graph.operations.values():
+            input_quantization_cfg = [TensorQuantizationConfig(
+                policy=sample_cfg.policy,
+                rounding=sample_cfg.rounding,
+                num_of_bits=sample_cfg.num_of_bits,
+                quant_min=sample_cfg.quant_min,
+                quant_max=sample_cfg.quant_max,
+                scale=None,
+                offset=None,
+                observer_algorithm=sample_cfg.observer_algorithm)]
+            output_quantization_cfg = [input_quantization_cfg[0].copy()]
+            # computing layers
+            if len(op.parameters) > 0:
+                for cfg in computing_op.config.input_quantization_config[1:]:
+                    assert isinstance(cfg, TensorQuantizationConfig)
+                    input_quantization_cfg.append(cfg.copy())
+            # add 
+            else:
+                input_quantization_cfg.append(input_quantization_cfg[0].copy())
+            configs[op.name] = OperationQuantizationConfig(input_quantization_cfg, output_quantization_cfg)
+        
+        for op_name, cfg in configs.items():
+            processer(QuantizeOperationCommand(op_name, computing_op.platform, cfg))
+    
+    def build_quantization_pipeline(self, computing_op: QuantableOperation) -> List[QuantizationOptimizationPass]:
+        # routine passes
+        quantization_pipeline = [
+            QuantizeReducePass(),
+            ParameterQuantizePass(method=computing_op.config.input_quantization_config[1].observer_algorithm),
+            RuntimeCalibrationPass(method=computing_op.config.input_quantization_config[0].observer_algorithm),
+            QuantAlignmentPass(),
+            PassiveParameterQuantizePass()
+        ]
+        return quantization_pipeline
+    
+    def prepare_for_quantization(
+        self,
+        computing_op: QuantableOperation,
+        graph: BaseGraph,
+        first_child_weight: torch.Tensor,
+        second_child_weight: torch.Tensor,
+        first_child_bias: Union[torch.Tensor, None],
+        second_child_bias: Union[torch.Tensor, None]
+    ) -> None:
+        # change weight values of computing layers according to split point
+        # initialize all state for calibration
+        graph.variables[f'{computing_op.name}_first_child_weight'].value = first_child_weight
+        graph.variables[f'{computing_op.name}_second_child_weight'].value = second_child_weight
+        if first_child_bias is not None and second_child_bias is not None:
+            graph.variables[f'{computing_op.name}_first_child_bias'].value = first_child_bias
+            graph.variables[f'{computing_op.name}_second_child_bias'].value = second_child_bias
+
+        for op in graph.operations.values():
+            if isinstance(op, QuantableOperation):
+                op.store_parameter_value()
+                for cfg, var in op.config_with_variable:
+                    if cfg.state == QuantizationStates.ACTIVATED or cfg.state == QuantizationStates.SLAVE:
+                        cfg.state = QuantizationStates.INITIAL
+                        if cfg._father_config != cfg:
+                            cfg._father_config = cfg
+                    elif cfg.state == QuantizationStates.PASSIVE:
+                        cfg.state = QuantizationStates.PASSIVE_INIT
+
+    def prepare_data(self,
+            computing_op: QuantableOperation,
+            executor: TorchExecutor,
+            dataloader: Iterable,
+            calib_steps: int,
+            collate_fn: Callable
+    ) -> List[torch.Tensor]:
+        # prepare data for subgraph input
+        input_data = []
+        calib_step = 0
+        for calib_epoch in range(ceil(calib_steps / len(dataloader))):
+            for data in dataloader:
+                if collate_fn is not None:
+                    data = collate_fn(data)
+                input_data.extend(executor.forward(data, output_names=[computing_op.inputs[0].name]))
+                calib_step += 1
+                if calib_step >= calib_steps: break
+        return input_data
+    
+    def split_weight(self,
+                    op: QuantableOperation,
+                    sub_graph: BaseGraph,
+                    weight: torch.Tensor,
+                    split_point: float,
+                    bias: Union[torch.Tensor, None]
+    ) -> Tuple[torch.Tensor]:
+        abs_max = weight.abs().max()
+        if op.type == 'Conv' or op.type == 'ConvTranspose':
+            channel_filter = (weight.reshape(weight.shape[0], -1).max(dim=1)[0] > abs_max * split_point).float()
+            first_child_weight = weight * channel_filter.reshape(-1, 1, 1, 1)
+            second_child_weight = weight * (1 - channel_filter.reshape(-1, 1, 1, 1))
+            
+        elif op.type == 'Gemm':
+            channel_filter = (weight.reshape(weight.shape[0], -1).max(dim=1)[0] > abs_max * split_point).float()
+            first_child_weight = weight * channel_filter.reshape(-1, 1)
+            second_child_weight = weight * (1 - channel_filter.reshape(-1, 1))
+
+        if len(op.parameters) == 2:
+            first_child_bias = bias * channel_filter
+            second_child_bias = bias * (1 - channel_filter)
+        else:
+            first_child_bias, second_child_bias = None, None
+        self.prepare_for_quantization(op, sub_graph, first_child_weight, \
+                    second_child_weight, first_child_bias, second_child_bias)
+    
+    def compute_original_loss(
+        self,
+        computing_op: QuantableOperation,
+        dataloader: List[torch.Tensor],
+        calib_steps: int,
+        device: Union[str, torch.device]
+    ) -> float:
+        # build single-op graph for computing original fp-quant MSE loss
+        single_op_graph = BaseGraph(name='TempGraph', built_from=NetworkFramework.NATIVE)
+        input_var, output_var = Variable(name='Input'), Variable(name='Output')
+        weight_param = Variable(name='weight_param', value=computing_op.parameters[0].value , is_parameter=True)
+        
+        single_op_graph.append_variable(input_var)
+        single_op_graph.append_variable(output_var)
+        single_op_graph.append_variable(weight_param)
+
+        conv_op = Operation(name='ConvOp', op_type='Conv', attributes=computing_op.attributes,\
+                    inputs=[input_var, weight_param], outputs=[output_var])
+        single_op_graph.append_operation(conv_op)
+
+        if len(computing_op.parameters) == 2:
+            bias = Variable(name='bias_param', value=computing_op.parameters[1].value, is_parameter=True, dest_ops=[conv_op])
+            single_op_graph.append_variable(bias)
+            conv_op.inputs.append(bias)
+        
+        input_var.dest_ops.append(conv_op)
+        weight_param.dest_ops.append(conv_op)
+
+        output_var.source_op = conv_op
+        single_op_graph.inputs['Input']   = input_var
+        single_op_graph.outputs['Output'] = output_var
+
+        sub_executor  = TorchExecutor(single_op_graph, False, device)
+        self.trace_meta(sub_executor, dataloader)
+        sub_processer = QuantableGraph(GraphReplacer(single_op_graph))
+        self.quantize(computing_op, sub_processer)
+        sub_executor.load_graph(single_op_graph)
+        sub_quantization_pipeline = self.build_quantization_pipeline(computing_op)
+
+        for pipeline in sub_quantization_pipeline:
+            pipeline.optimize(sub_processer, dataloader, sub_executor, calib_steps=calib_steps, collate_fn=None)
+
+        return compute_loss(['Output'], single_op_graph, dataloader, None, sub_executor)['Output']
+    
+    def merge_graph(self, graph: BaseGraph, sub_graph: BaseGraph, replace_op: QuantableOperation) -> None:
+        # a fast and simple way to directly merge sub_graph into original graph
+        # the replace_op will be removed from graph and subsititued by ops in the
+        # sub_graph
+
+        # append variable
+        for var in sub_graph.variables.values():
+            if var.name not in sub_graph.inputs and var.name not in sub_graph.outputs:
+                assert var.name not in graph.variables
+                graph.variables[var.name] = var
+        input_var, output_var = replace_op.inputs[0], replace_op.outputs[0]
+
+        first_child  = sub_graph.operations[f'{replace_op.name}_first_child']
+        second_child = sub_graph.operations[f'{replace_op.name}_second_child']
+        add_receiver = sub_graph.operations[f'{replace_op.name}_Add_Receiver']
+        
+        # cut off connection in the original graph
+        input_var.dest_ops.pop(input_var.dest_ops.index(replace_op))
+        output_var.source_op = None
+        replace_op.inputs.pop(0)
+        replace_op.outputs.pop(0)
+        graph.delete_operation(replace_op.name)
+        # connect input_var with subgraph
+        input_var.dest_ops.extend([first_child, second_child])
+        first_child.inputs[0].dest_ops.clear()
+        first_child.inputs.pop(0)
+        second_child.inputs.pop(0)
+        first_child.inputs.insert(0, input_var)
+        second_child.inputs.insert(0, input_var)
+
+        # connect output_var with subgraph
+        add_receiver.outputs.pop(0)
+        add_receiver.outputs.append(output_var)
+        output_var.source_op = add_receiver
+
+        # append operations in sub_graph
+        graph.append_operation(first_child)
+        graph.append_operation(second_child)
+        graph.append_operation(add_receiver)
+        
+        # clear sub_graph
+        sub_graph.operations.clear()
+        sub_graph.variables.clear()
+    
+    def trace_meta(self, executor: TorchExecutor, dataloader: Iterable, collate_fn: Callable=None) -> None:
+        for data in dataloader:
+            if collate_fn is not None:
+                data = collate_fn(data)
+            executor.tracing_operation_meta(data)
+            break
+
+    def optimize(self,
+                processer: GraphCommandProcesser,
+                dataloader: Iterable,
+                executor: BaseGraphExecutor,
+                calib_steps: int,
+                collate_fn: Callable,
+                **kwargs
+    ) -> None:
+        for op_name in self.interested_layers:
+            assert op_name in processer.graph.operations, f'{op_name} is not in current graph'
+            op = processer.graph.operations[op_name]
+            assert op.is_computing_op and isinstance(op, QuantableOperation), \
+                f'only quantable computing op supports weight split'
+            
+            op = processer.graph.operations[op_name]
+            sub_graph = self.init_tri_op_graph(op)
+            sub_executor = TorchExecutor(graph=sub_graph, fp16_mode=False, device=executor._device)
+            sub_dataloader = self.prepare_data(op, executor, dataloader, calib_steps, collate_fn)
+            self.trace_meta(sub_executor, sub_dataloader)
+            sub_processer = QuantableGraph(GraphReplacer(sub_graph))
+            self.quantize(op, sub_processer)
+            sub_executor.load_graph(graph=sub_graph)
+            sub_quantization_pipeline = self.build_quantization_pipeline(op)
+
+            weight, bias = op.parameters[0].value, None
+            if len(op.parameters) == 2:
+                bias = op.parameters[1].value
+
+            losses = []
+            for split_point in np.arange(0.005, 1.00, 0.005):
+                self.split_weight(op, sub_graph, weight, split_point, bias)
+                for pipeline in sub_quantization_pipeline:
+                    pipeline.optimize(sub_processer, sub_dataloader, sub_executor, calib_steps=calib_steps, collate_fn=None)
+                loss = compute_loss(['Output'], sub_graph, sub_dataloader, None, sub_executor)['Output']
+                losses.append((split_point, loss))
+                logger.debug(f'Split Point {split_point :.2f} || MSE Loss {loss :.6f}')
+
+            losses = sorted(losses, key=lambda x: x[1])
+            original_loss = self.compute_original_loss(op, sub_dataloader, calib_steps, executor._device)
+            logger.info(f'Original MSE Loss {original_loss :.6f}')
+
+            if losses[0][1] < self.loss_reduce_thre * original_loss:
+                self.split_weight(op, sub_graph, weight, losses[0][0], bias)
+                self.merge_graph(processer.graph, sub_graph, op)
+                executor.load_graph(processer.graph)
+                self.trace_meta(executor, dataloader, collate_fn)
+
+                logger.info(f'{op.name} splitted successfully, original loss: {original_loss :.6f}'
+                    f' => splitted loss : {losses[0][1] :.6f}')
+            else:
+                logger.warning(f'{op.name} fail to split due to loss not improved enough')
 
 
 class ChannelSplitPass(QuantizationOptimizationPass):
@@ -477,6 +834,7 @@ class MetaxGemmSplitPass(QuantizationOptimizationPass):
     def __init__(self, name: str = 'Metax Gemm Split Pass') -> None:
         super().__init__(name)
     
+    # Implementation of Gemm Split will move to IR.morph soon.
     def optimize(self, processer: GraphCommandProcesser, 
                  dataloader: Iterable, executor: BaseGraphExecutor, **kwargs) -> None:
         morpher = GraphReplacer(processer)
@@ -513,4 +871,4 @@ class MetaxGemmSplitPass(QuantizationOptimizationPass):
                 raise ValueError(f'Can not process with operation {op.name}, transA=1 is not allowed.')
             if op.attributes.get('transB') == 1:
                 inserting_matmul.inputs[-1].value = torch.permute(inserting_matmul.inputs[-1].value, (1, 0))
-            
+

--- a/ppq/quantization/optim/parameters.py
+++ b/ppq/quantization/optim/parameters.py
@@ -42,47 +42,51 @@ class PassiveParameterQuantizePass(QuantizationOptimizationPass):
             if op.type in {'Conv', 'ConvTranspose', 'Gemm'}:
                 # inputs are [input value, weight, bias(optional)]
                 if op.num_of_input == 3:
-                    weight_config = op.config.input_quantization_config[1]
-                    input_config = op.config.input_quantization_config[0]
-                    if not check_state(weight_config.state):
+                    i_cfg, w_cfg, b_cfg = op.config.input_quantization_config
+                    if b_cfg.state != QuantizationStates.PASSIVE_INIT: continue
+                    if not check_state(w_cfg.state):
                         raise PermissionError(f'Can not quantize bias of layer {op.name}, '
                             'cause weight has not been correctly quantized.')
-                    if not check_state(input_config.state):
+                    if not check_state(i_cfg.state):
                         raise PermissionError(f'Can not quantize bias of layer {op.name}, '
                             'cause input has not been correctly quantized.')
-                    weight_config = weight_config.dominated_by
-                    input_config  = input_config.dominated_by
+                    w_cfg = w_cfg.dominated_by
+                    i_cfg  = i_cfg.dominated_by
 
-                    bias_config = op.config.input_quantization_config[-1]
-                    bias_config.scale  = weight_config.scale * input_config.scale * self.scale_multiplier
-                    bias_config.state  = QuantizationStates.PASSIVE
-                    bias_config.offset = torch.zeros_like(bias_config.scale)
-                    assert not bias_config.policy.has_property(QuantizationProperty.ASYMMETRICAL), (
+                    b_cfg.scale  = w_cfg.scale * i_cfg.scale * self.scale_multiplier
+                    b_cfg.state  = QuantizationStates.PASSIVE
+                    b_cfg.offset = torch.zeros_like(b_cfg.scale)
+                    assert not b_cfg.policy.has_property(QuantizationProperty.ASYMMETRICAL), (
                         'Passive parameter does not support ASYMMETRICAL quantization')
 
             if op.type in {'Clip'}:
                 # inputs are [input value, min[optional], max[optional]]
-                input_config = op.config.input_quantization_config[0]
-                if not check_state(input_config.state):
+                i_cfg = op.config.input_quantization_config[0]
+                
+                if not check_state(i_cfg.state):
                     raise PermissionError(f'Can not quantize clip value of layer {op.name}, '
                         'cause input has not been correctly quantized.')
-                input_config = input_config.dominated_by
+                i_cfg = i_cfg.dominated_by
                 for config in op.config.input_quantization_config[1: ]:
-                    config.scale  = input_config.scale
-                    config.offset = input_config.offset
+                    if config.state != QuantizationStates.PASSIVE_INIT: continue
+
+                    config.scale  = i_cfg.scale
+                    config.offset = i_cfg.offset
                     config.state  = QuantizationStates.PASSIVE
 
             if op.type in {'Pad'}:
                 # inputs are [input value, pad[shape-related], pad value[optional]]
                 if op.num_of_input != 3: continue
-                input_config = op.config.input_quantization_config[0]
-                if not check_state(input_config.state):
+                i_cfg = op.config.input_quantization_config[0]
+                if i_cfg.state != QuantizationStates.PASSIVE_INIT: continue
+                
+                if not check_state(i_cfg.state):
                     raise PermissionError(f'Can not quantize pad value of layer {op.name}, '
                         'cause input has not been correctly quantized.')
-                input_config = input_config.dominated_by
+                i_cfg = i_cfg.dominated_by
                 pad_config = op.config.input_quantization_config[-1]
-                pad_config.scale  = input_config.scale
-                pad_config.offset = input_config.offset
+                pad_config.scale  = i_cfg.scale
+                pad_config.offset = i_cfg.offset
                 pad_config.state  = QuantizationStates.PASSIVE
 
 

--- a/ppq/quantization/quantizer/GRUQuantizer.py
+++ b/ppq/quantization/quantizer/GRUQuantizer.py
@@ -1,18 +1,25 @@
 from typing import Union
 
 import torch
-from ppq.IR import Operation
-from ppq.core import (ChannelwiseTensorQuantizationConfig, OperationMeta,
+from ppq.api.setting import *
+from ppq.core import (ChannelwiseTensorQuantizationConfig,
                       OperationQuantizationConfig, QuantizationPolicy,
                       QuantizationProperty, QuantizationStates, RoundingPolicy,
                       TargetPlatform)
+from ppq.executor.base import BaseGraphExecutor
 from ppq.IR import BaseGraph, GraphCommandProcesser
+from ppq.IR.base.graph import Operation
+from ppq.quantization.optim import (NxpInputRoundingRefinePass,
+                                    NXPResizeModeChangePass,
+                                    QuantizationOptimizationPipeline)
+
 from .base import BaseQuantizer
 
 
-class TensorRTQuantizer(BaseQuantizer):
+class NXP_Quantizer(BaseQuantizer):
     def __init__(
-        self, graph: Union[BaseGraph, GraphCommandProcesser]
+        self,
+        graph: Union[BaseGraph, GraphCommandProcesser],
     ) -> Union[torch.Tensor, list, dict]:
 
         self._num_of_bits = 8
@@ -21,14 +28,17 @@ class TensorRTQuantizer(BaseQuantizer):
 
         super().__init__(graph=graph)
 
-    def init_quantize_config(
-        self, operation: Operation) -> OperationQuantizationConfig:
+    def build_quant_pipeline(
+        self, setting: QuantizationSetting, executor: BaseGraphExecutor) -> QuantizationOptimizationPipeline:
+        pipeline = super().build_quant_pipeline(setting, executor)
+        return pipeline
+
+    def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
         base_quant_config = self.create_default_quant_config(
             policy=self.quantize_policy, rounding=self.rounding_policy,
-            operation_meta=operation.meta_data, num_of_bits=self._num_of_bits,
+            operation_meta=operation.meta_data, num_of_bits=self._num_of_bits, 
             quant_max=self._quant_max, quant_min=self._quant_min,
-            observer_algorithm='percentile'
-        )
+            observer_algorithm='percentile')
 
         if operation.type in {'Conv', 'ConvTranspose', 'Gemm'}:
             # set all parameters within Conv, ConvTranspose, Gemm to per-channel quant-config.
@@ -41,13 +51,10 @@ class TensorRTQuantizer(BaseQuantizer):
                 conv_weight_config.policy = QuantizationPolicy(
                     QuantizationProperty.SYMMETRICAL +
                     QuantizationProperty.LINEAR +
-                    QuantizationProperty.PER_CHANNEL
+                    QuantizationProperty.PER_TENSOR +
+                    QuantizationProperty.POWER_OF_2
                 )
-                base_quant_config.input_quantization_config[1] = \
-                    ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
-                        convert_from = conv_weight_config,
-                        offsets = None, scales  = None, channel_axis = 0
-                    )
+                conv_weight_config.rounding = RoundingPolicy.ROUND_HALF_EVEN
                 base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
             # first parameter must exits, for gemm layer it will be gemm_weight
             # layout: [in_dim, out_dim]
@@ -56,23 +63,40 @@ class TensorRTQuantizer(BaseQuantizer):
                 gemm_weight_config.policy = QuantizationPolicy(
                     QuantizationProperty.SYMMETRICAL +
                     QuantizationProperty.LINEAR +
-                    QuantizationProperty.PER_CHANNEL
+                    QuantizationProperty.PER_TENSOR +
+                    QuantizationProperty.POWER_OF_2
                 )
+                gemm_weight_config.rounding = RoundingPolicy.ROUND_HALF_EVEN
                 base_quant_config.input_quantization_config[1] = \
                     ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
                         convert_from = gemm_weight_config,
-                        offsets = None, scales  = None, channel_axis = 0
+                        offsets = None, scales = None, channel_axis = 0
                     )
                 base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
             # if operation has bias
             if operation.num_of_input > 2:
                 bias_config = base_quant_config.input_quantization_config[-1]
-                bias_config.state = QuantizationStates.FP32
+                bias_config.policy = QuantizationPolicy(
+                    QuantizationProperty.SYMMETRICAL +
+                    QuantizationProperty.LINEAR +
+                    QuantizationProperty.PER_TENSOR +
+                    QuantizationProperty.POWER_OF_2
+                )
+                bias_config.num_of_bits = 30
+                bias_config.quant_max = int(pow(2, 30))
+                bias_config.quant_min = - int(pow(2, 30))
+                bias_config.state = QuantizationStates.PASSIVE_INIT
+                base_quant_config.input_quantization_config[-1].observer_algorithm = 'Minmax'
+
+        if operation.type in PASSIVE_OPERATIONS:
+            # Those op are not active op.
+            base_quant_config.is_active_quant_op = False
+        
         return base_quant_config
 
     @ property
     def target_platform(self) -> TargetPlatform:
-        return TargetPlatform.TRT_INT8
+        return TargetPlatform.NXP_INT8
 
     @ property
     def default_platform(self) -> TargetPlatform:
@@ -81,8 +105,11 @@ class TensorRTQuantizer(BaseQuantizer):
     @ property
     def quant_operation_types(self) -> set:
         return {
-            'Conv', 'Gemm', 'ConvTranspose', 
-            'AveragePool', 'GlobalAveragePool'
+            'Conv', 'ConvTranspose', 'Gemm', 'Relu', 'PRelu', 
+            'Clip', 'Pad', 'Resize', 'MaxPool', 'AveragePool',
+            'GlobalMaxPool', 'GlobalAveragePool',
+            'Mul', 'Add', 'Max', 'Sub', 'Div',
+            'LeakyRelu', 'Concat', 'Sigmoid', 'Slice', 'Gru', 'Lstm'
         }
 
     @ property
@@ -90,9 +117,10 @@ class TensorRTQuantizer(BaseQuantizer):
         return QuantizationPolicy(
             QuantizationProperty.SYMMETRICAL +
             QuantizationProperty.LINEAR +
-            QuantizationProperty.PER_TENSOR
+            QuantizationProperty.PER_TENSOR +
+            QuantizationProperty.POWER_OF_2
         )
 
     @ property
-    def rounding_policy(self) -> RoundingPolicy:
+    def rounding_policy(self):
         return RoundingPolicy.ROUND_HALF_EVEN

--- a/ppq/quantization/quantizer/MyQuantizer.py
+++ b/ppq/quantization/quantizer/MyQuantizer.py
@@ -50,7 +50,7 @@ class ExtQuantizer(BaseQuantizer):
             调用这个函数将直接产生一个默认的量化配置，你可以在此基础上进行修改。
         
         注意并不是所有算子都可以使用默认量化配置完成量化，有些算子明显具有更加复杂的量化逻辑
-            对于这种情况，你需要手动创建它们的量化配置信息。
+            对于这种情况，你需要在此函数中手动创建它们的量化配置信息。
         
         Initial your quantization configuration for each operation.
             (This function will be invoked by BaseQuantizer as an interface.)
@@ -113,7 +113,7 @@ class ExtQuantizer(BaseQuantizer):
             所有量化区的算子将被调度到这个设备上。
         
         Property target_platform is acquired by graph dispather.
-            It states where your quantized operation deploy.
+            It states where your quantized operation depoly.
         
         """
         return TargetPlatform.EXTENSION
@@ -125,7 +125,7 @@ class ExtQuantizer(BaseQuantizer):
             所有冲突区的算子将被调度到这个设备上。
         
         Property default_platform is acquired by graph dispather.
-            It states where non-quantable operation deploy.
+            It states where non-quantable operation depoly.
 
         """
         return TargetPlatform.FP32
@@ -136,10 +136,18 @@ class ExtQuantizer(BaseQuantizer):
         quant_operation_types 指明了所有可以被量化的算子类型。
         
         聪明的你可能想问了，如果我不是按类型进行量化，而是想特定去量化某几个算子怎么办。
-            我建议你通过手写一个调度表来实现这样的功能，只需要把其他算子调度到FP32上就行了。 
+            我建议你通过手写一个调度表来实现这样的功能，只需要把其他算子调度到FP32上就行了。
+        
+        请注意，并不是你写在这里的类型就一定会被量化，在量化之前还有调度器进行子图切分，
+            只有量化子图上的算子才可以被量化。 
         
         Property quant_operation_types contains all quantable operations' type.
         
+        Notice that PPQ has a dispatching logic before quantizer,
+            so to say quantizer is only in charge of quantable subgraph,
+            those operation within non-quantable subgraph will never be
+            quantized even their type is listed here.
+
         """
         return {
             'Conv', 'ConvTranspose', 'Gemm', 'Relu', 'PRelu',

--- a/ppq/quantization/quantizer/base.py
+++ b/ppq/quantization/quantizer/base.py
@@ -259,6 +259,13 @@ class BaseQuantizer(metaclass = ABCMeta):
             grid_aware        = channel_split_setting.grid_aware
             ))
 
+        if setting.weight_split:
+            weight_split_setting = setting.weight_split_setting
+            list_of_passes.append(WeightSplitPass(
+                interested_layers = weight_split_setting.interested_layers,
+                loss_reduce_thre  = weight_split_setting.loss_reduce_thre
+            ))
+
         if setting.fusion:
             fusion_setting  = setting.fusion_setting
             if fusion_setting.refine_quantization:


### PR DESCRIPTION
* 重写了 TensorRT 的导出逻辑，现在PPQ使用 onnx qdq 格式直接导出engine
* 重写了 onnxruntime 导出逻辑
* 完善了 lsq 算法与 Qdrop 的 cuda 实现，现在它们还有一些问题，我们将在0.6.4的后续更新中将其加入advanced optimization pass
* 修改了 adavanced optimization 逻辑，现在不启动cuda kernel的情况下不允许使用这个pass
* 对创建 TensorMeta 的过程添加了检查，现在不允许以空类型创建TensorMeta
* 修改了cuda kernel的报错字符串，现在它更容易读懂了一些。
---
* 添加了MetaxExporter
* 添加了WeightSplitPass
* 添加了一个新的量化平台HEXAGON_INT8 = 801，我们将在这个平台上尝试量化GRU
* 添加了操作计算图的函数insert_op_between_var_and_op
* 添加了GraphDecomposer类，我们将在 0.6.4 的后续更新中使用这个类完成算子分解任务
