### PR TITLE
修复了一个由强制联合定点引起的罕见错误

### DIFF
--- a/ppq/quantization/optim/parameters.py
+++ b/ppq/quantization/optim/parameters.py
@@ -31,6 +31,7 @@ class PassiveParameterQuantizePass(QuantizationOptimizationPass):
 
         def check_state(state: QuantizationStates): 
             return state in {
+                QuantizationStates.SLAVE,
                 QuantizationStates.ACTIVATED,
                 QuantizationStates.BAKED,
                 QuantizationStates.OVERLAPPED


### PR DESCRIPTION
执行concat强制联合定点时，如果网络结构复杂，有可能将conv, gemm等算子的输入或输出状态置为 SLVAE，这种情况下被动量化将会产生错误。