### PR TITLE
添加了第二类图模式匹配算法(Preview Feature)

### DIFF
--- a/ppq/IR/search.py
+++ b/ppq/IR/search.py
@@ -70,6 +70,7 @@ class OperationSet(set):
         for item in removing:
             self.remove(item)
 
+
 class TraversalCommand(GraphCommand):
     def __init__(self,
         sp_expr: Union[PointPattern, Callable],
@@ -165,6 +166,238 @@ class TraversalCommand(GraphCommand):
             [type]: [description]
         """
         pass
+
+
+class TreeNode:
+    def __init__(self, idx: int, pattern: Callable, edges: List[int]) -> None:
+        self.idx     = idx
+        self.pattern = pattern
+        self.edges   = edges
+
+
+class PatternTree(Iterable):
+    def __init__(self, patterns: List[Callable], edges: List[List[int]]) -> None:
+        """
+        Pattern Tree 是一个用来表示图模式的结构体
+        这将在图中检索任意一个抽象树形结构
+        
+        你将使用 Pattern Tree 定义你的树结构
+        使用 patterns 确定每一个节点需要满足的条件
+        使用 edges 将节点们彼此相连从而构成树形结构
+        
+        patterns[0] 将被设定为树的根节点
+
+        Args:
+            patterns (List[Callable]): _description_
+            edges (List[List[int]]): _description_
+
+        Raises:
+            TypeError: _description_
+            TypeError: _description_
+            ValueError: _description_
+        """
+        for pattern in patterns:
+            if not isinstance(pattern, Callable):
+                raise TypeError(f'Can not create Pattern Tree with pattern {str(pattern)} it is not callable.')
+        for edge in edges:
+            if not isinstance(edge, tuple) and not isinstance(edge, list):
+                raise TypeError(f'Can not create Pattern Tree with edge {str(edge)} it is not tuple or list.')
+            if len(edge) != 2:
+                raise ValueError(f'Can not create Pattern Tree with edge {str(edge)} '
+                                 f'it should contains exact 2 elements, however {len(edge)} was given.')
+            sp, ep = edge
+            if not isinstance(sp, int) or not isinstance(ep, int):
+                raise TypeError(f'Can not create Pattern Tree was given edge {[str(sp), str(ep)]}, '
+                                'expect int value here.')
+        '''
+        if len(edges) != len(patterns) - 1:
+            raise ValueError('Can not create Pattern with you input, input node and edges is not a tree. '
+                             '[num of edges != num of nodes - 1]')
+        '''
+
+        forward_stars = {node_id: [] for node_id in range(len(patterns))}
+        for sp, ep in edges: forward_stars[sp].append(ep)
+
+        self._nodes = [TreeNode(idx, pattern, forward_stars[idx]) for idx, pattern in enumerate(patterns)]
+        self.root = self._nodes[0]
+
+    def following_patterns(self, node_idx: int) -> List[Callable]:
+        node = self._nodes[node_idx]
+        return [self._nodes[following_node].pattern for following_node in node.edges]
+
+    def __getitem__(self, idx: int) -> TreeNode:
+        return self._nodes[idx]
+
+    def __iter__(self) -> Iterator[TreeNode]:
+        return super().__iter__()
+
+
+class HungarianSolver:
+    def __init__(self, num_of_ops: int, num_of_patterns: int, matches: List[List[int]]) -> None:
+        """
+        Hungarian Solver - Part of Tree Pattern Matching Algorithm
+        For complex pattern, there might be more than 1 corresponding op was founded,
+        Example:
+        pt = PatternTree(
+                patterns = [lambda x: x.is_computing_op, lambda x: x.is_computing_op, 'Conv', 'Mul']
+                edges = [[0, 1], [1, 2], [2, 3], [0, 3]])
+        
+            pt create an abstract tree pattern of:
+                                            --- lambda x: x.is_computing_op  --
+            lambda x: x.is_computing_op --- +                                 + --- 'Mul'
+                                            --- 'Conv'                       --
+
+        There is an pattern overlap between x.is_computing_op and 'Conv', 
+            so pattern x.is_computing_op might have more than 1 matchings.
+        
+        in this case, we use hungarian algorithm to find an optimal matching(maximum).
+            if there is more than 1 optimal matching, this solver will return ARBITRARY ONE.
+
+        Args:
+            num_of_ops (int):
+
+            num_of_patterns (int): 
+
+            matches (List[List[int]]): matches is a collection of op - pattern matchings,
+                if matches = [[0, 0], [1, 1], [2, 2]], 
+                    it means op0 is matched with pattern 0
+                    it means op1 is matched with pattern 1
+                    it means op2 is matched with pattern 2
+            
+            Hungarian Algorithm will find an optimial matching between ops and patterns.
+        """
+        self.neighbor_table  = {node_idx: set() for node_idx in range(num_of_patterns)}
+        self.num_of_ops      = num_of_ops
+        self.num_of_patterns = num_of_patterns
+        self.matched         = [-1 for _ in range(num_of_ops)]
+        for sp, ep in matches: 
+            self.neighbor_table[sp].add(ep)
+    
+    def solve(self) -> bool:
+        # 有一个匹配失败就立即返回，无需继续计算
+        visited = [False for _ in range(self.num_of_ops)] 
+        for i in range(self.num_of_ops):
+            if not self._solve(i, visited): return False
+        return True
+
+    def _solve(self, pattern: int, visited: List[bool]) -> bool:
+        for ep in self.neighbor_table[pattern]:
+            if visited[ep]: continue
+            visited[ep] = True
+            if self.matched[ep] == -1 or self._solve(self.matched[ep], visited):
+                self.matched[ep] = pattern
+                return True
+        return False
+
+
+class TypeExpr(Callable):
+    def __init__(self, type: str) -> None:
+        self.type = type
+        super().__init__()
+    
+    def __call__(self, op: Operation) -> bool:
+        return op.type == self.type
+
+
+class TreePatternMatcher:
+    def __init__(self, pattern_tree: PatternTree) -> None:
+        """
+        TreePatternMatcher offers you a really powerful pattern matching tool that helps
+        you finding specific structure from your graph. Define your network structure with
+        pattern tree --- an internal data sturcture of PPQ, then extract corresponding graph 
+            structures from ppq graph via TreePatternMatcher.
+        
+        This feature will benifits you a lot when dealing with graph fusion and graph editing.
+        PPQ use Depth First Search and Hungarian Algorithm to match pattern from your graph,
+            be aware that for complex pattern it might cost a lot of time in matching.
+        
+        Time complexity: O(nkd^3), 
+            where n is the num of operation in your graph,
+            k is the num of pattern in your pattern tree,
+            d is the maximum drgree in your graph.
+        
+        Notice in most cases it won't reach this complexity,
+        it always have a complexity like O(nk)
+        
+        ATTENTION: Do not use poorly designed pattern which might cause multiple matching results.
+                   For this case, ppq will randomly pick one matched result and return.
+         
+        Example:
+            pt = PatternTree(
+                patterns = [lambda x: x.is_computing_op, 'Softplus', 'Tanh', 'Mul']
+                edges = [[0, 1], [1, 2], [2, 3], [0, 3]])
+        
+            pt create an abstract tree pattern of:
+                                            --- 'Softplus'   ---   'Tanh' --
+            lambda x: x.is_computing_op --- +                              + --- 'Mul'
+                                            ---     ---     ---    ---    --
+
+        Args:
+            pattern_tree (PatternTree): _description_
+        """
+        self.pattern_tree   = pattern_tree
+        self._interal_store = []
+        self.results        = []
+        
+    def match(self, graph: BaseGraph, exclusive: bool) -> List[List[Operation]]:
+        root, candidates = self.pattern_tree.root, []
+
+        # match root from graph, futher pattern matching will start from root.
+        for operation in graph.operations.values():
+            if root.pattern(operation):
+                candidates.append(operation)
+
+        for op in candidates:
+            self._interal_store = [None for _ in range(len(self.pattern_tree._nodes))]
+            self._interal_store[0] = op
+            if self._match(graph=graph, op=op, node_idx=0, exclusive=exclusive):
+                self.results.append(self._interal_store)
+        return self.results
+        
+    def _match(self, graph: BaseGraph, op: Operation, node_idx: int, exclusive: bool) -> bool:
+        pnode, following_ops = self.pattern_tree[node_idx], graph.get_downstream_operations(op)
+        num_of_ops, num_of_patterns = len(following_ops), len(self.pattern_tree.following_patterns(node_idx))
+        
+        # 递归终止于 pattern 结尾
+        if len(pnode.edges) == 0:
+            self._interal_store[node_idx] = op
+            return True
+
+        matches = []
+        for op_idx, downstream_op in enumerate(following_ops):
+            for pattern_idx, pattern in enumerate(self.pattern_tree.following_patterns(node_idx)): 
+                if pattern(downstream_op):
+                    matches.append((pattern_idx, op_idx))
+
+        # exclusive 模式，不允许节点有额外输出边
+        if exclusive and num_of_ops != num_of_patterns: 
+            return False
+        
+        # pattern 可以匹配到多个不同的节点，最坏情况下，找出所有可行的匹配方案时间复杂度为 n!
+        # 其中 n 为 op 的下游节点个数，对于这种情况，我们不可能枚举所有匹配方案并完成算法 (P-completed)。
+        # 如果 pattern 匹配到了多个节点，我们使用匈牙利算法找出任意一个最优匹配，并警告用户这样做的不完备性与随机性。
+        # 作为用户，你不应该输入有歧义的 pattern.
+        # 例如下面的 pattern:
+        #   nodes = [lambda x: x.is_computing_op, 'Mul', 'Mul', 'Mul', ...]
+        #   edges = [[0, 1], [0, 2], [0, 3], ...]
+        # 树形匹配将有 3! 种可行方案，我们将随机选取其中一种，进一步枚举可能产生不可预期的结果
+        matching_solver = HungarianSolver(
+            num_of_ops = num_of_ops, 
+            num_of_patterns = num_of_patterns,
+            matches = matches)
+        
+        # 二部图匹配失败，直接返回 False
+        if not matching_solver.solve():
+            return False
+
+        # 二部图匹配成功，则 matching_solver.matched 中按顺序存储了匹配到的 op index
+        # 以此继续向下递归
+        for pattern_idx, op_idx in enumerate(matching_solver.matched):
+            self._interal_store[node_idx] = op
+            flag = self._match(graph=graph, op=following_ops[op_idx], 
+                               node_idx=pnode.edges[pattern_idx], exclusive=exclusive)
+            if not flag: return False
+        return True
 
 
 class SearchableGraph(GraphCommandProcesser):
@@ -427,3 +660,14 @@ class SearchableGraph(GraphCommandProcesser):
             concat, op = path[0], path[-1]
             concat_matchings[concat.name].append(op.name)
         return dict(concat_matchings)
+
+    def pattern_matching(self, patterns: List[Callable], 
+                         edges: List[List[int]], exclusive: bool = True) -> List[List[Operation]]:
+        # compile string to type expr.
+        for pidx in range (len(patterns)):
+            pfunc = patterns[pidx]
+            if isinstance(pfunc, str):
+                patterns[pidx] = TypeExpr(pfunc)
+        
+        pm = TreePatternMatcher(PatternTree(patterns=patterns, edges=edges))
+        return pm.match(self.graph, exclusive=exclusive)


### PR DESCRIPTION
该方法允许你定义一个模板子图，并在ppq 计算图上搜索子图

子图必须有根节点，但未必需要是树，必须联通。
子图模板的定义包含两部分：
1. 子图内所有节点的匹配条件
2. 子图内所有节点的相连关系

        Example:
            pt = PatternTree(
                patterns = [lambda x: x.is_computing_op, 'Softplus', 'Tanh', 'Mul']
                edges = [[0, 1], [1, 2], [2, 3], [0, 3]])
        
            pt create an abstract tree pattern of:
                                            --- 'Softplus'   ---   'Tanh' --
            lambda x: x.is_computing_op --- +                              + --- 'Mul'
                                            ---     ---     ---    ---    --
请注意模板必须被定义为无二义性的，目前它还不是很完善，因此没有加入到 ppq ir 的指令体系中。