### PR TITLE
feat(default.py): add AdaptiveAvgPool2d

### DIFF
--- a/ppq/executor/op/torch/__init__.py
+++ b/ppq/executor/op/torch/__init__.py
@@ -1,4 +1,4 @@
-from .default import (DEFAULT_BACKEND_TABLE, AveragePool_forward,
+from .default import (DEFAULT_BACKEND_TABLE, AveragePool_forward, AdaptiveAvgPool2d_forward,
                       BatchNormalization_forward, Cast_forward, Clip_forward,
                       Concat_forward, Constant_forward,
                       ConstantOfShape_forward, Conv_forward, Eltwise_forward,

--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -23,7 +23,7 @@ __all__ = [
     'BatchNormalization_forward', 'Cast_forward', 'Clip_forward', 'Concat_forward',
     'Constant_forward', 'ConstantOfShape_forward', 'Conv_forward', 'Eltwise_forward', 'Equal_forward',
     'UnaryEltwise_forward', 'Expand_forward', 'Flatten_forward', 'Gather_forward', 'GatherND_forward', 'Gemm_forward',
-    'Grid_sampler_forward', 'AveragePool_forward', 'Greater_forward', 'Less_forward', 'MatMul_forward',
+    'Grid_sampler_forward', 'AdaptiveAvgPool2d_forward', 'AveragePool_forward', 'Greater_forward', 'Less_forward', 'MatMul_forward',
     'MaxPool2d_forward', '_NMS_forward', 'NonZero_forward', 'Not_forward', 'Range_forward',
     'ReduceL2_forward', 'ReduceMax_forward', 'Reshape_forward', 'Resize_forward', 'ScatterElements_forward',
     'ScatterND_forward', 'Shape_forward', 'Slice_forward', 'Softmax_forward', 'Squeeze_forward', 'Tile_forward',
@@ -481,6 +481,12 @@ def AveragePool_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBac
 
     output = F.avg_pool2d(input_value, kernel_size=kernel_size,
                           padding=padding, stride=stride, ceil_mode=ceil_mode)
+    return output
+
+
+def AdaptiveAvgPool2d_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    input_value, output_size = values
+    output = F.adaptive_avg_pool2d(input_value, output_size)
     return output
 
 
@@ -2128,6 +2134,7 @@ def Identity_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBacken
 
 
 DEFAULT_BACKEND_TABLE = {
+    'AdaptiveAvgPool2d': AdaptiveAvgPool2d_forward,
     'Add': Add_forward,
     'ArgMax': ArgMax_forward,
     'AveragePool': AveragePool_forward,

--- a/ppq/executor/torch.py
+++ b/ppq/executor/torch.py
@@ -114,7 +114,7 @@ class TorchExecutor(BaseGraphExecutor, torch.nn.Module):
         self._default_quant_fn = PPQLinearQuantFunction
         self._deployed = False
         self._device = device
-        self._executing_contenxt = TorchBackendContext(executing_device=self._device)
+        self._executing_context = TorchBackendContext(executing_device=self._device)
         super().__init__(graph)
         self._runnable_graph = RunnableGraph(self._graph)
         self._delegates = {}
@@ -363,7 +363,7 @@ class TorchExecutor(BaseGraphExecutor, torch.nn.Module):
                     else: raise TypeError(f'invalid hook instance was given with operation: {operation}')
 
                 # forward and collecting result
-                outputs = operation_forward_func(operation, inputs, self._executing_contenxt)
+                outputs = operation_forward_func(operation, inputs, self._executing_context)
                 outputs = outputs if isinstance(outputs, (list, tuple)) else [outputs]
                 fp_outputs = outputs
 

--- a/ppq/quantization/optim/morph.py
+++ b/ppq/quantization/optim/morph.py
@@ -39,7 +39,7 @@ class NXPResizeModeChangePass(QuantizationOptimizationPass):
 
 
 class NCNNFormatGemmPass(QuantizationOptimizationPass):
-    def __init__(self, name: str = 'NCNN Format Gemm Pass') -> None:
+    def __init__(self, name: str = 'ncnn Format Gemm Pass') -> None:
         super().__init__(name)
 
     def optimize(self, processor: GraphCommandProcessor, dataloader: Iterable,

--- a/ppq/quantization/optim/refine.py
+++ b/ppq/quantization/optim/refine.py
@@ -681,7 +681,7 @@ class MishFusionPass(QuantizationOptimizationPass):
             mul.config.input_quantization_config[1].dominated_by        = master_config
 
 class NCNNRequantizePass(QuantizationOptimizationPass):
-    def __init__(self, name: str = 'NCNN Requantize Scale Unify') -> None:
+    def __init__(self, name: str = 'ncnn Requantize Scale Unify') -> None:
         super().__init__(name)
 
     def optimize(self, processor: GraphCommandProcessor, 

--- a/ppq/quantization/optim/training.py
+++ b/ppq/quantization/optim/training.py
@@ -1069,7 +1069,7 @@ class AdvancedQuantOptimization(TrainingBasedPass):
         loss_ema    = EMARecorder(beta=0.98)
         cur_iter    = 0
         delegators  = []
-        device      = executor._executing_contenxt.executing_device
+        device      = executor._executing_context.executing_device
         output_var  = block.ep.outputs[0]
         input_var   = block.sp.inputs[0]
         dataset = RandomMemDataset(data=[[qt, fp] for qt, fp in zip(quant_inputs, fp32_outputs)])
@@ -1280,7 +1280,7 @@ class LearningToCalibPass(TrainingBasedPass):
                         delegators.append(BanditDelegator(arms=self.arms, config=cfg))
         delegators = [d for d in delegators if isinstance(d, BanditDelegator)]
         dataset = RandomMemDataset(data=[[qt, fp] for qt, fp in zip(quant_inputs, fp32_outputs)])
-        device  = executor._executing_contenxt.executing_device
+        device  = executor._executing_context.executing_device
         loss_ema    = EMARecorder(beta=0.98)
         output_var  = block.ep.outputs[0]
         input_var   = block.sp.inputs[0]


### PR DESCRIPTION
* 新增 AdaptiveAvgPool2d，用于 resnet-cifar。命名和 [torch](https://pytorch.org/docs/stable/generated/torch.nn.AdaptiveAvgPool2d.html) 保持一致
* 修个 fix-typo
* 注释里的 NCNN 都改 ncnn，代码的不敢瞎动算了