### PR TITLE
修改onnxexporter的导出逻辑

### DIFF
--- a/ppq/IR/morph.py
+++ b/ppq/IR/morph.py
@@ -671,7 +671,7 @@ class GraphDecomposer(GraphCommandProcessor):
             output_var = op.outputs[0]
 
             if op.num_of_input == 3:
-                bias_add  = graph.create_operation(op_type='Add')
+                bias_add  = graph.create_operation(op_type='Add', platform=op.platform)
                 bias_var  = op.inputs[-1]
 
                 graph.create_link_with_op(

--- a/ppq/quantization/analyse/layerwise.py
+++ b/ppq/quantization/analyse/layerwise.py
@@ -106,17 +106,14 @@ def layerwise_error_analyse(
             fp_outputs = executor.forward(inputs=batch, output_names=interested_outputs)
 
             # manually override quantization state
-            for cfg, _ in operation.config_with_variable:
-                cfg.state = QuantizationStates.ACTIVATED
+            operation.restore_quantize_state()
             qt_outputs = executor.forward(inputs=batch, output_names=interested_outputs)
 
             for fp_output, qt_output in zip(fp_outputs, qt_outputs):
                 recorder.update(y_pred = qt_output, y_real = fp_output)
 
             # manually override quantization state
-            for cfg, _ in operation.config_with_variable:
-                cfg.state = QuantizationStates.DEQUANTIZED
-
+            operation.dequantize()
             if idx >= steps: break
 
     # restore quantization states


### PR DESCRIPTION
* 修改onnxruntiem的导出逻辑，现在导出所有 ppq 中的量化操作，即使它们已经是overlap的。