### PR TITLE
Support Custimize Everything.

### DIFF
--- a/ppq/executor/base.py
+++ b/ppq/executor/base.py
@@ -36,6 +36,23 @@ GLOBAL_DISPATCHING_TABLE[TargetPlatform.EXTENSION] = EXTENSION_BACKEND_TABLE
 GLOBAL_DISPATCHING_TABLE[TargetPlatform.OPENVINO_INT8] = DEFAULT_BACKEND_TABLE
 
 def register_operation_handler(handler: Callable, operation_type: str, platform: TargetPlatform):
+    """Regitser a custimized function as operation handler.
+    
+    Function should accept at least 3 input parameters, return one or more tensor as result:
+    func(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    
+    If there is already another operation handler for given operation_type,
+        new handler will replace the old one without warrning.
+
+    Args:
+        handler (Callable): _description_
+        operation_type (str): _description_
+        platform (TargetPlatform): _description_
+
+    Raises:
+        ValueError: _description_
+        ValueError: _description_
+    """
     if platform not in GLOBAL_DISPATCHING_TABLE:
         raise ValueError('Unknown Platform detected, Please check your platform setting.')
     if operation_type in GLOBAL_DISPATCHING_TABLE[platform]:

--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -2253,6 +2253,14 @@ def Reciprocal_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBack
     return 1 / x
 
 
+def LogSoftmax_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
+ 
+    x = Softmax_forward(op=op, values=values, ctx=ctx, kwargs=kwargs)
+    x = Log_forward(op=op, values=[x], ctx=ctx, kwargs=kwargs)
+    return x
+
 
 DEFAULT_BACKEND_TABLE = {
     'AdaptiveAvgPool2d': AdaptiveAvgPool2d_forward,
@@ -2284,6 +2292,7 @@ DEFAULT_BACKEND_TABLE = {
     'LayerNorm': LayerNorm_forward,
     'LeakyRelu': LeakyRelu_forward,
     'Less': Less_forward,
+    'LogSoftmax': LogSoftmax_forward,
     'MatMul': MatMul_forward,
     'Max': Eltwise_forward,
     'MaxPool': MaxPool2d_forward,
@@ -2342,4 +2351,5 @@ DEFAULT_BACKEND_TABLE = {
     'Identity': Identity_forward,
     'OneHot': Onehot_forward,
     'Reciprocal': Reciprocal_forward,
+
 }

--- a/ppq/parser/onnxruntime_exporter.py
+++ b/ppq/parser/onnxruntime_exporter.py
@@ -294,7 +294,7 @@ class ONNXRUNTIMExporter(OnnxExporter):
                 if config.state == QuantizationStates.PASSIVE_BAKED:
                     config.state = QuantizationStates.PASSIVE
 
-                if QuantizationStates.can_export(config.state):
+                if QuantizationStates.can_export(config.state) and config.state != QuantizationStates.FP32:
                     # if not quant parameter to int, all parameter should export as fp32.
                     # needs insert both quant and dequant op for them
                     if not quant_param_to_int:
@@ -310,7 +310,7 @@ class ONNXRUNTIMExporter(OnnxExporter):
             else:
                 if not process_activation: continue
 
-                if QuantizationStates.can_export(config.state):
+                if QuantizationStates.can_export(config.state) and config.state != QuantizationStates.FP32:
                     created = self.insert_quant_on_variable(
                         graph=graph, var=var, config=config, related_op=op, meta=meta)
                     var = created.outputs[0]

--- a/ppq/parser/tensorRT.py
+++ b/ppq/parser/tensorRT.py
@@ -134,7 +134,7 @@ class TensorRTExporter(ONNXRUNTIMExporter):
         # find all quantable operations:
         for operation in [op for op in graph.operations.values()]:
             if not isinstance(operation, QuantableOperation): continue
-            if operation.type in {'Conv', 'Gemm', 'ConvTranspose'}:
+            if operation.type in {'Conv', 'Gemm', 'ConvTranspose', 'MatMul'}:
                 # for Conv, Gemm, ConvTranspose, TensorRT wants their weight to be quantized,
                 # however bias remains fp32.
                 assert len(operation.config.input_quantization_config) >= 2, (

--- a/ppq/quantization/observer/range.py
+++ b/ppq/quantization/observer/range.py
@@ -62,7 +62,7 @@ class TorchMinMaxObserver(BaseTensorObserver):
                     'Your quantization config has PER_CHANNEL while it is not a '\
                     'ChannelwiseTensorQuantizationConfig instance.'
                 channel_axis = self._quant_cfg.channel_axis
-                channelwise_view = value.transpose(dim0=0, dim1=channel_axis)
+                channelwise_view = value.transpose(dim0=0, dim1=channel_axis).unsqueeze(-1)
                 channelwise_view = torch.flatten(channelwise_view, start_dim=1)
                 self._min_val_collector.append(torch.min(channelwise_view, dim=1, keepdim=True)[0])
                 self._max_val_collector.append(torch.max(channelwise_view, dim=1, keepdim=True)[0])

--- a/ppq/quantization/quantizer/AcademicQuantizer.py
+++ b/ppq/quantization/quantizer/AcademicQuantizer.py
@@ -17,11 +17,10 @@ class ACADEMICQuantizer(BaseQuantizer):
     designed only for purpose of paper reproducing and algorithm verification.
     """
     def __init__(self, graph: BaseGraph, verbose: bool = True) -> None:
+        super().__init__(graph, verbose)
         self._num_of_bits = 8
         self._quant_min = 0
         self._quant_max = 255
-        super().__init__(graph, verbose)
-
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
 
@@ -115,10 +114,10 @@ class ACADEMICQuantizer(BaseQuantizer):
 
 class ACADEMIC_INT4_Quantizer(ACADEMICQuantizer):
     def __init__(self, graph: BaseGraph, verbose: bool = True) -> None:
+        super().__init__(graph, verbose)
         self._num_of_bits = 4
         self._quant_min = 0
         self._quant_max = 15
-        super().__init__(graph, verbose)
 
     @ property
     def target_platform(self) -> TargetPlatform:

--- a/ppq/quantization/quantizer/DSPQuantizer.py
+++ b/ppq/quantization/quantizer/DSPQuantizer.py
@@ -18,12 +18,10 @@ class PPL_DSP_Quantizer(BaseQuantizer):
         self,
         graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = 0
         self._quant_max = int(pow(2, self._num_of_bits) - 1)
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
 
@@ -75,7 +73,7 @@ class PPL_DSP_Quantizer(BaseQuantizer):
             'GlobalMaxPool', 'GlobalAveragePool', 'Softmax',
             'Mul', 'Add', 'Max', 'Sub', 'Div', 'Reshape',
             'LeakyRelu', 'Concat', 'Sigmoid', 'Slice', 'Interp',
-            'ReduceMean', 'Flatten',
+            'ReduceMean'
         }
 
     @ property

--- a/ppq/quantization/quantizer/FPGAQuantizer.py
+++ b/ppq/quantization/quantizer/FPGAQuantizer.py
@@ -18,12 +18,10 @@ class FPGAQuantizer(BaseQuantizer):
         self,
         graph: Union[BaseGraph, GraphCommandProcessor],
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = - 128
         self._quant_max = + 127
-
-        super().__init__(graph=graph)
 
     def build_quant_pipeline(
         self, setting: QuantizationSetting, executor: BaseGraphExecutor) -> QuantizationOptimizationPipeline:

--- a/ppq/quantization/quantizer/MetaxQuantizer.py
+++ b/ppq/quantization/quantizer/MetaxQuantizer.py
@@ -20,12 +20,10 @@ class MetaxTensorwiseQuantizer(BaseQuantizer):
         self,
         graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = 0
         self._quant_max = 255
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
 
@@ -104,12 +102,10 @@ class MetaxChannelwiseQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = -127
         self._quant_max = 127
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
         base_quant_config = self.create_default_quant_config(

--- a/ppq/quantization/quantizer/MyQuantizer.py
+++ b/ppq/quantization/quantizer/MyQuantizer.py
@@ -31,15 +31,14 @@ class ExtQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph) # do not forget to initialize super class.
+        
         # Quantization basic setting -------------------------
         # update following properties:
         self._num_of_bits = 8        # platform bit width.
         self._quant_min = -128       # int value min
         self._quant_max = +127       # int value max
         # ----------------------------------------------------
-
-        super().__init__(graph=graph) # do not forget to initialize super class.
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
         """使用这个函数来初始化算子的量化配置，该函数会被父类作为接口调用。

--- a/ppq/quantization/quantizer/NCNNQuantizer.py
+++ b/ppq/quantization/quantizer/NCNNQuantizer.py
@@ -8,7 +8,7 @@ from ppq.core import (ChannelwiseTensorQuantizationConfig, PASSIVE_OPERATIONS,
                       TargetPlatform)
 from ppq.executor.base import BaseGraphExecutor
 from ppq.IR import BaseGraph, GraphCommandProcessor, Operation
-from ppq.quantization.optim import QuantizationOptimizationPipeline, NCNNFormatGemmPass
+from ppq.quantization.optim import QuantizationOptimizationPipeline, NCNNFormatGemmPass, NCNNRequantizePass
 
 from .base import BaseQuantizer
 
@@ -17,17 +17,21 @@ class NCNNQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = - 127
         self._quant_max = + 127
-
-        super().__init__(graph=graph)
 
     def build_prequant_pipeline(
         self, setting: QuantizationSetting, executor: BaseGraphExecutor) -> QuantizationOptimizationPipeline:
         pipeline = super().build_prequant_pipeline(setting, executor)
         pipeline.append_optimization_to_pipeline(NCNNFormatGemmPass(), at_front=True)
+        return pipeline
+
+    def build_quant_pipeline(
+        self, setting: QuantizationSetting, executor: BaseGraphExecutor) -> QuantizationOptimizationPipeline:
+        pipeline = super().build_quant_pipeline(setting, executor)
+        pipeline.append_optimization_to_pipeline(NCNNRequantizePass())
         return pipeline
 
     def init_quantize_config(

--- a/ppq/quantization/quantizer/NCNNQuantizer.py
+++ b/ppq/quantization/quantizer/NCNNQuantizer.py
@@ -2,13 +2,14 @@ from typing import Union
 
 import torch
 from ppq.api.setting import QuantizationSetting
-from ppq.core import (ChannelwiseTensorQuantizationConfig, PASSIVE_OPERATIONS,
+from ppq.core import (ChannelwiseTensorQuantizationConfig,
                       OperationQuantizationConfig, QuantizationPolicy,
                       QuantizationProperty, QuantizationStates, RoundingPolicy,
                       TargetPlatform)
 from ppq.executor.base import BaseGraphExecutor
 from ppq.IR import BaseGraph, GraphCommandProcessor, Operation
-from ppq.quantization.optim import QuantizationOptimizationPipeline, NCNNFormatGemmPass, NCNNRequantizePass
+from ppq.quantization.optim import (NCNNFormatGemmPass,
+                                    QuantizationOptimizationPipeline)
 
 from .base import BaseQuantizer
 

--- a/ppq/quantization/quantizer/NXPQuantizer.py
+++ b/ppq/quantization/quantizer/NXPQuantizer.py
@@ -21,12 +21,10 @@ class NXP_Quantizer(BaseQuantizer):
         self,
         graph: Union[BaseGraph, GraphCommandProcessor],
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = - int(pow(2, self._num_of_bits - 1))
         self._quant_max = int(pow(2, self._num_of_bits - 1) - 1)
-
-        super().__init__(graph=graph)
 
     def build_quant_pipeline(
         self, setting: QuantizationSetting, executor: BaseGraphExecutor) -> QuantizationOptimizationPipeline:

--- a/ppq/quantization/quantizer/ORTQuantizer.py
+++ b/ppq/quantization/quantizer/ORTQuantizer.py
@@ -15,12 +15,10 @@ class ORT_PerTensorQuantizer(BaseQuantizer):
         self,
         graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = 0
         self._quant_max = int(pow(2, self._num_of_bits) - 1)
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
 
@@ -94,12 +92,10 @@ class ORT_PerChannelQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = 0
         self._quant_max = int(pow(2, self._num_of_bits) - 1)
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
         base_quant_config = self.create_default_quant_config(

--- a/ppq/quantization/quantizer/OpenvinoQuantizer.py
+++ b/ppq/quantization/quantizer/OpenvinoQuantizer.py
@@ -14,12 +14,10 @@ class OpenvinoQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = 0
         self._quant_max = 255
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(
         self, operation: Operation) -> OperationQuantizationConfig:

--- a/ppq/quantization/quantizer/PPLQuantizer.py
+++ b/ppq/quantization/quantizer/PPLQuantizer.py
@@ -16,12 +16,10 @@ class PPLCUDAQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = - int(pow(2, self._num_of_bits - 1))
         self._quant_max = int(pow(2, self._num_of_bits - 1) - 1)
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
         base_quant_config = self.create_default_quant_config(

--- a/ppq/quantization/quantizer/TRTQuantizer.py
+++ b/ppq/quantization/quantizer/TRTQuantizer.py
@@ -14,12 +14,10 @@ class TensorRTQuantizer(BaseQuantizer):
     def __init__(
         self, graph: Union[BaseGraph, GraphCommandProcessor]
     ) -> Union[torch.Tensor, list, dict]:
-
+        super().__init__(graph=graph)
         self._num_of_bits = 8
         self._quant_min = - 128
         self._quant_max = + 127
-
-        super().__init__(graph=graph)
 
     def init_quantize_config(
         self, operation: Operation) -> OperationQuantizationConfig:

--- a/ppq/quantization/quantizer/TRTQuantizer.py
+++ b/ppq/quantization/quantizer/TRTQuantizer.py
@@ -31,40 +31,42 @@ class TensorRTQuantizer(BaseQuantizer):
         )
         base_quant_config.output_quantization_config[0].state = QuantizationStates.FP32
 
-        if operation.type in {'Conv', 'ConvTranspose', 'Gemm'}:
+        if operation.type in {'Conv', 'ConvTranspose', 'Gemm', 'MatMul'}:
             # set all parameters within Conv, ConvTranspose, Gemm to per-channel quant-config.
             assert operation.num_of_input > 0, 'Seems you got a Conv layer with no parameters.'
 
             # first parameter must exits, for conv layer it will be conv_weight
             # layout: [out_channel, in_channel, kernel_size, kernel_size]
             if operation.type in {'Conv', 'ConvTranspose'}:
-                conv_weight_config = base_quant_config.input_quantization_config[1]
-                conv_weight_config.policy = QuantizationPolicy(
-                    QuantizationProperty.SYMMETRICAL +
-                    QuantizationProperty.LINEAR +
-                    QuantizationProperty.PER_CHANNEL
-                )
-                base_quant_config.input_quantization_config[1] = \
-                    ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
-                        convert_from = conv_weight_config,
-                        offsets = None, scales  = None, channel_axis = 0
+                if operation.inputs[1].is_parameter:
+                    conv_weight_config = base_quant_config.input_quantization_config[1]
+                    conv_weight_config.policy = QuantizationPolicy(
+                        QuantizationProperty.SYMMETRICAL +
+                        QuantizationProperty.LINEAR +
+                        QuantizationProperty.PER_CHANNEL
                     )
-                base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
+                    base_quant_config.input_quantization_config[1] = \
+                        ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
+                            convert_from = conv_weight_config,
+                            offsets = None, scales  = None, channel_axis = 0
+                        )
+                    base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
             # first parameter must exits, for gemm layer it will be gemm_weight
             # layout: [in_dim, out_dim]
-            elif operation.type in {'Gemm'}:
-                gemm_weight_config = base_quant_config.input_quantization_config[1]
-                gemm_weight_config.policy = QuantizationPolicy(
-                    QuantizationProperty.SYMMETRICAL +
-                    QuantizationProperty.LINEAR +
-                    QuantizationProperty.PER_CHANNEL
-                )
-                base_quant_config.input_quantization_config[1] = \
-                    ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
-                        convert_from = gemm_weight_config,
-                        offsets = None, scales  = None, channel_axis = 0
+            elif operation.type in {'Gemm', 'MatMul'}:
+                if operation.inputs[1].is_parameter:
+                    gemm_weight_config = base_quant_config.input_quantization_config[1]
+                    gemm_weight_config.policy = QuantizationPolicy(
+                        QuantizationProperty.SYMMETRICAL +
+                        QuantizationProperty.LINEAR +
+                        QuantizationProperty.PER_CHANNEL
                     )
-                base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
+                    base_quant_config.input_quantization_config[1] = \
+                        ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
+                            convert_from = gemm_weight_config,
+                            offsets = None, scales  = None, channel_axis = 0
+                        )
+                    base_quant_config.input_quantization_config[1].observer_algorithm = 'Minmax'
             # if operation has bias
             if operation.num_of_input > 2:
                 bias_config = base_quant_config.input_quantization_config[-1]

--- a/ppq/quantization/quantizer/base.py
+++ b/ppq/quantization/quantizer/base.py
@@ -113,12 +113,12 @@ class BaseQuantizer(metaclass = ABCMeta):
                 operation_platforms[op_name] = self.target_platform
             else: operation_platforms[op_name] = self.default_platform
 
-            # manual override.
+            # maunnl override.
             if op_name in operation_platforms:
                 operation.platform = operation_platforms[op_name]
 
         # build operation_quantization_configs
-        # every quantizable op MUST have a quantization config
+        # every quantable op MUST have a quantization config
         # if operation.type is listed in quantable_operation_types while a operation_quantization_configs is given
         # it will override the setting of quantable_operation_types
         for op_name, operation in self._graph.operations.items():

--- a/ppq/quantization/quantizer/base.py
+++ b/ppq/quantization/quantizer/base.py
@@ -14,7 +14,6 @@ from ppq.IR.base.graph import Operation
 from ppq.IR.morph import GraphReplacer
 from ppq.IR.quantize import QuantableVariable
 from ppq.IR.search import SearchableGraph
-from ppq.executor.torch import TorchExecutor
 from ppq.quantization.optim import *
 
 
@@ -31,6 +30,10 @@ class BaseQuantizer(metaclass = ABCMeta):
         self._verbose = verbose
         self._processor_chain = None
         self._graph = graph
+        
+        self._quant_min = -128
+        self._quant_max = +127
+        self._num_of_bits = 8
 
     @ empty_ppq_cache
     def quantize(
@@ -153,6 +156,8 @@ class BaseQuantizer(metaclass = ABCMeta):
                                    'make sure all operations that you sent to quantized platform is '
                                    'quantable and recognizable for your quantizer.')
                 quantization_config = operation_quantization_configs[op_name]
+                assert isinstance(quantization_config, OperationQuantizationConfig), (
+                    f'Expect an Operation Quantization Config here, however {type(quantization_config)} was given.')
                 self._processor_chain(
                     QuantizeOperationCommand(
                         op_name=operation.name,
@@ -170,6 +175,10 @@ class BaseQuantizer(metaclass = ABCMeta):
         quant_min: int, quant_max: int, observer_algorithm: str,
         policy: QuantizationPolicy, rounding: RoundingPolicy,
     ) -> OperationQuantizationConfig:
+        assert isinstance(policy, QuantizationPolicy), (
+            f'Can not create quantization config - Quantization Policy Type Error.')
+        assert isinstance(rounding, RoundingPolicy), (
+            f'Can not create quantization config - Rounding Policy Type Error.')
         num_of_related_vars = operation_meta.num_of_input + operation_meta.num_of_output
         configs = [TensorQuantizationConfig(
             policy=policy, rounding=rounding,
@@ -184,7 +193,12 @@ class BaseQuantizer(metaclass = ABCMeta):
 
     @ abstractmethod
     def init_quantize_config(self, operation: Operation) -> OperationQuantizationConfig:
-        raise NotImplementedError('Quantizier does not have a default operation quantization config yet.')
+        base_quant_config = self.create_default_quant_config(
+            policy=self.quantize_policy, rounding=self.rounding_policy,
+            operation_meta=operation.meta_data, num_of_bits=self._num_of_bits,
+            quant_max=self._quant_max, quant_min=self._quant_min,
+            observer_algorithm='percentile')
+        return base_quant_config
 
     @ abstractproperty
     @ property
@@ -196,25 +210,22 @@ class BaseQuantizer(metaclass = ABCMeta):
     def target_platform(self) -> TargetPlatform:
         raise NotImplementedError('Quantizier does not have a default platform setting yet.')
 
-    @ abstractproperty
     @ property
     def default_platform(self) -> TargetPlatform:
-        raise NotImplementedError('Quantizier does not have a default platform setting yet.')
+        return TargetPlatform.FP32
 
     @ abstractproperty
     @ property
     def quantize_policy(self) -> QuantizationPolicy:
         raise NotImplementedError('Quantizier does not have a default quantization policy yet.')
 
-    @ abstractproperty
     @ property
-    def rounding_policy(self):
-        raise NotImplementedError('Implement this first.')
+    def rounding_policy(self) -> RoundingPolicy:
+        return RoundingPolicy.ROUND_HALF_EVEN
 
-    @ abstractproperty
     @ property
     def activation_fusion_types(self) -> set:
-        raise NotImplementedError('Implement this first.')
+        return {'Relu', 'Clip'}
 
     def report(self) -> str:
         debug_str = ''

--- a/ppq/samples/custimized_quant.py
+++ b/ppq/samples/custimized_quant.py
@@ -1,0 +1,93 @@
+"""这个脚本将教会你如何使用 PPQ 量化自定义算子，同时完全自定义量化行为"""
+
+import torch
+from ppq import *
+from ppq.api import *
+from ppq.quantization.quantizer import TensorRTQuantizer
+
+B = 1
+T = 64
+MODEL_PATH = 'models\encoder_ln.onnx'
+
+def generate_samples(num_of_samples: int = 32):
+    """生成样本数据，把这个函数改成真实数据读入就可以完成量化了
+    这个语音数据量很小 我建议你把整个数据集直接全部送上CUDA
+    """
+    sample = {
+        'speech': torch.rand(size=[B, T, 80]).float().cuda(),
+        'speech_lengths': torch.ones(size=[B]).int().cuda()}
+    samples = [sample for _ in range(num_of_samples)]
+    return samples
+SAMPLES = generate_samples()
+
+# 定义一个自己的量化器，定制量化行为，继承于 TensorRTQuantizer 量化器
+class MyTensorRTQuantizer(TensorRTQuantizer):
+    @ property
+    def quant_operation_types(self) -> set:
+        """覆盖 quant_operation_types  自定义需要量化的算子"""
+        return {'LayerNormPlugin'}
+
+    def init_quantize_config(
+        self, operation: Operation) -> OperationQuantizationConfig:
+        config = super().init_quantize_config(operation=operation)
+        """针对 LayerNormPlugin 生成量化配置信息"""
+        if operation.type == 'LayerNormPlugin': 
+            wconfig = config.input_quantization_config[1] # weight config
+            bconfig = config.input_quantization_config[2]
+            
+            wconfig.policy = QuantizationPolicy(    # weight 做 Per channel 量化
+                QuantizationProperty.SYMMETRICAL +
+                QuantizationProperty.LINEAR +
+                QuantizationProperty.PER_TENSOR)
+            bconfig.state = QuantizationStates.FP32 # bias 不量化
+            '''
+            # 将 weight config 升级为 ChannelwiseTensorQuantizationConfig
+            config.input_quantization_config[1] = ( 
+                ChannelwiseTensorQuantizationConfig.convert_from_tensor_config(
+                    convert_from = wconfig,
+                    offsets = None, scales = None, 
+                    channel_axis = 0))
+            '''
+            config.input_quantization_config[1].observer_algorithm = 'Minmax'
+        return config
+
+def layernorm_forward(op: Operation, values: List[torch.Tensor], ctx = None, **kwargs):
+    """自定义算子的前向传播函数"""
+    return values[0]
+
+register_operation_handler(
+    handler=layernorm_forward, 
+    operation_type='LayerNormPlugin', 
+    platform=TargetPlatform.TRT_INT8)
+
+register_network_quantizer(
+    quantizer=MyTensorRTQuantizer,
+    platform=TargetPlatform.TRT_INT8)
+
+with ENABLE_CUDA_KERNEL():
+    QS = QuantizationSettingFactory.trt_setting()
+    ir = load_onnx_graph(onnx_import_file=MODEL_PATH)
+    # 默认调度失效，直接手动调度所有 LayerNormPlugin 送上量化区
+    for op in ir.operations.values():
+        if op.type == 'LayerNormPlugin':
+            QS.dispatching_table.append(operation=op.name, platform=TargetPlatform.TRT_INT8)
+    
+    # 这个网络是 opset 13 的， 先转换一些不支持的算子...
+    for op in ir.operations.values():
+        if op.type in {'Unsqueeze', 'Squeeze', 'ReduceSum'}:
+            axes = op.inputs[1].value
+            ir.remove_variable(removing_var=op.inputs[1])
+            op.attributes['axes'] = axes.tolist()
+    
+    qir = quantize_native_model(
+        model=ir, calib_dataloader=SAMPLES, calib_steps=32, 
+        input_shape=None, inputs=SAMPLES[0], 
+        platform=TargetPlatform.TRT_INT8, setting=QS)
+
+    graphwise_error_analyse(
+        graph=qir, running_device='cuda', 
+        dataloader=SAMPLES)
+
+    export_ppq_graph(
+        graph=qir, platform=TargetPlatform.ONNXRUNTIME, 
+        graph_save_to='quantized.onnx')


### PR DESCRIPTION
* 添加了 'register_network_quantizer', 'register_network_parser', 'register_network_exporter', 'register_operation_handler'函数，你将使用这四个函数来完全自定义量化过程，为此我们添加了一个新的文件教你如何去做：ppq/samples/custimized_quant.py
* 添加了LogSoftmax_forward，ReduceSum_forward, GreaterOrEqual_forward

@tpoisonooo 你可以参考 custimized_quant.py 中的例子来完成复杂网络量化的支持，新的函数将使得自定义量化更加容易。