### PR TITLE
Fusion, Seting, Example Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ PPL QuantTool 是一个高效的工业级的神经网络量化工具.
 | `自定义量化` |  |  |  |  |
 | 添加自定义量化平台 1 | - | pytorch | [link](https://github.com/openppl-public/ppq/blob/master/md_doc/add_new_platform.md) ||
 | 添加自定义量化平台 2 | - | pytorch | [link](https://github.com/openppl-public/ppq/blob/master/ppq/samples/create_your_platform.py) ||
-| 添加自定义算子 3 | - | pytorch | [link](https://github.com/openppl-public/ppq/blob/master/ppq/samples/custimize_quant_func.py) ||
+| 注册量化代理函数 | - | pytorch | [link](https://github.com/openppl-public/ppq/blob/master/ppq/samples/custimize_quant_func.py) ||
+| 自定义量化算子 | - | pytorch | [link](https://github.com/openppl-public/ppq/blob/master/ppq/samples/custimized_quant.py) ||
 
 
 # Video Tutorial(Bilibili 视频教程)

--- a/ppq/IR/__init__.py
+++ b/ppq/IR/__init__.py
@@ -1,6 +1,6 @@
 from .base.command import GraphCommand, GraphCommandType
 from .base.graph import (BaseGraph, GraphBuilder, GraphExporter, Operation,
-                         OperationExporter, Variable)
+                         OperationExporter, Variable, Opset)
 from .deploy import RunnableGraph
 from .morph import GraphFormatter, GraphMerger, GraphReplacer
 from .processer import DefaultGraphProcessor, GraphCommandProcessor

--- a/ppq/IR/base/graph.py
+++ b/ppq/IR/base/graph.py
@@ -3,21 +3,55 @@ from collections import deque
 from typing import Any, Dict, List
 
 import torch
-from ppq.core import (COMPUTING_OP, LINEAR_ACTIVATIONS, SOI_OP,
+from ppq.core import (COMPUTING_OP, DEFAULT_OPSET_DOMAIN,
+                      DEFAULT_OPSET_VERSION, LINEAR_ACTIVATIONS, SOI_OP,
                       NetworkFramework, OperationMeta, Serializable,
                       SingletonMeta, TargetPlatform, TensorMeta, ppq_warning)
+
+
+class Opset():
+    def __init__(self, domain: str = DEFAULT_OPSET_DOMAIN, version: int = DEFAULT_OPSET_VERSION) -> None:
+        """Open Neural Network Exchange (ONNX) is an open ecosystem that empowers AI developers 
+            to choose the right tools as their project evolves. 
+        
+        ONNX provides an open source format for AI models, both deep learning and traditional ML. 
+        It defines an extensible computation graph model, as well as definitions of
+            built-in operators and standard data types. 
+        Currently we focus on the capabilities needed for inferencing (scoring).
+        
+        PPQ IR is built based on ONNX defination.
+
+        Args:
+            domain (str, optional): _description_. Defaults to DEFAULT_OPSET_DOMAIN.
+            version (int, optional): _description_. Defaults to DEFAULT_OPSET_VERSION.
+        """
+        self.domain  = domain
+        self.version = version
+    
+    def is_onnx_v11(self):
+        return self.domain == 'ONNX' and self.version == 11
+    
+    def is_onnx(self):
+        return self.domain == 'ONNX'
+    
+    def is_caffe(self):
+        return self.domain == 'Caffe'
 
 
 class OperationBase(metaclass=ABCMeta):
     def __init__(self,
                  name: str, op_type: str,
                  attributes: Dict[str, Any],
+                 opset = None,
                  platform: TargetPlatform=TargetPlatform.UNSPECIFIED) -> None:
         self._name = name
         self._type = op_type
         self._attributes = attributes
         self._platform = platform
         self._meta = None
+        if opset is None:
+            self._opset = Opset()
+        else: self._opset = opset
 
     @ abstractproperty
     def inputs(self) -> List[Any]: pass

--- a/ppq/api/setting.py
+++ b/ppq/api/setting.py
@@ -162,9 +162,10 @@ class AdvancedOptimizationSetting():
 
 class ActivationQuantizationSetting():
     def __init__(self) -> None:
-        # 激活值校准算法，不区分大小写，可以选择 minmax, kl, percentile, MSE
+        # 激活值校准算法，不区分大小写，可以选择 minmax, kl, percentile, MSE, None
+        # 选择 None 时，将由 quantizer 指定量化算法
         # activation calibration method
-        self.calib_algorithm = 'percentile'
+        self.calib_algorithm = None
 
         # 执行逐层激活值校准，延长执行时间，提升精度
         # whether to calibrate activation per - layer.
@@ -178,9 +179,9 @@ class ActivationQuantizationSetting():
 
 class ParameterQuantizationSetting():
     def __init__(self) -> None:
-        # 参数校准算法，不区分大小写，可以选择 minmax, percentile(per-layer), kl(per-layer sym), MSE
+        # 参数校准算法，不区分大小写，可以选择 minmax, percentile(per-layer), kl(per-layer sym), MSE, None
         # parameter calibration method
-        self.calib_algorithm = 'minmax'
+        self.calib_algorithm = None
 
         # 是否处理被动量化参数
         # whether to process passive parameters

--- a/ppq/core/common.py
+++ b/ppq/core/common.py
@@ -53,6 +53,9 @@ OPTIM_ADVOPT_RLOSS_MULTIPLIER = 1
 # 是否使用 LR SCEHDULER
 OPTIM_ADVOPT_USING_SCEHDULER = True
 
+DEFAULT_OPSET_DOMAIN  = 'ONNX'
+DEFAULT_OPSET_VERSION = 11
+
 # ONNX 导出图的时候，opset的版本，这玩意改了可能就要起飞了
 ONNX_EXPORT_OPSET = 11
 # ONNX 导出图的时候，onnx version，这玩意改了可能就要起飞了


### PR DESCRIPTION
* 修改了默认量化策略，现在activation和parameter将默认采用quantizer的量化配置，而不是用setting中的算法覆盖它们的。
* 添加了一个叫做Opset的类型，现在还没什么用，未来我们将在这个数据结构的基础上支持opset13~opset11
* 将 relu 和 clip 的强制定点覆盖补充回来了
* 为 passive parameter的状态新增了检查