### PR TITLE
Core Update to 0.6.5

### DIFF
--- a/ProgramEntrance.py
+++ b/ProgramEntrance.py
@@ -152,7 +152,7 @@ with ENABLE_CUDA_KERNEL():
         platform=TARGET_PLATFORM,
         device=EXECUTING_DEVICE,
         do_quantize=True)
-
+    
     # -----------------------------------------------------------------
     # 我们允许你在标准量化流程之后添加自定义量化逻辑，通常在标准量化流程之后添加的逻辑用于：
     # 调整量化信息，再训练网络权重

--- a/ppq/__init__.py
+++ b/ppq/__init__.py
@@ -7,6 +7,7 @@ from ppq.IR import (BaseGraph, GraphCommand, GraphCommandProcessor,
                     Variable)
 from ppq.IR.quantize import QuantableOperation, QuantableVariable
 from ppq.IR.search import SearchableGraph
+from ppq.IR.deploy import RunnableGraph
 from ppq.log import *
 from ppq.quantization.analyse import (graphwise_error_analyse,
                                       layerwise_error_analyse,

--- a/ppq/__init__.py
+++ b/ppq/__init__.py
@@ -8,10 +8,10 @@ from ppq.IR import (BaseGraph, GraphCommand, GraphCommandProcessor,
 from ppq.IR.quantize import QuantableOperation, QuantableVariable
 from ppq.IR.search import SearchableGraph
 from ppq.log import *
-from ppq.quantization.analyse.graphwise import graphwise_error_analyse
-from ppq.quantization.analyse.layerwise import (layerwise_error_analyse,
-                                                parameter_analyse,
-                                                variable_analyse)
+from ppq.quantization.analyse import (graphwise_error_analyse,
+                                      layerwise_error_analyse,
+                                      parameter_analyse, statistical_analyse,
+                                      variable_analyse)
 from ppq.quantization.measure import (torch_cosine_similarity,
                                       torch_cosine_similarity_as_loss,
                                       torch_KL_divergence,

--- a/ppq/api/interface.py
+++ b/ppq/api/interface.py
@@ -577,6 +577,7 @@ def export_ppq_graph(
     platform: TargetPlatform,
     graph_save_to: str,
     config_save_to: str = None,
+    copy_graph: bool = False,
     **kwargs) -> None:
     """使用这个函数将 PPQ ir 保存到文件，同时导出 PPQ 的量化配置信息。 该函数可以将 PPQ ir 保存为不同格式的模型文件。 this
     func dumps ppq IR to file, and exports quantization setting information
@@ -600,6 +601,9 @@ def export_ppq_graph(
             note that some of platforms requires to write quantization setting
             directly into the model file, this parameter won't have effect at
             this situation
+            
+        copy_graph (bool): 导出图的时候是否需要把图复制一份
+            Whether to copy graph when export.
     """
     # 如果没有后缀名，就添加一个后缀名上来
     postfix = ''
@@ -621,6 +625,7 @@ def export_ppq_graph(
         raise KeyError(f'Requiring framework {platform} does not support export now.')
     exporter = EXPORTERS[platform]()
     assert isinstance(exporter, GraphExporter), 'Unexpected Exporter found.'
+    if copy_graph: graph = graph.copy()
     exporter.export(file_path=graph_save_to, config_path=config_save_to, graph=graph, **kwargs)
 
 

--- a/ppq/api/interface.py
+++ b/ppq/api/interface.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Iterable
 
 import torch
 from ppq.core import (NetworkFramework, TargetPlatform, empty_ppq_cache,
@@ -28,6 +28,8 @@ from ppq.quantization.quantizer import (ACADEMIC_INT4_Quantizer,
                                         PPLCUDAQuantizer, TensorRTQuantizer)
 from ppq.scheduler import DISPATCHER_TABLE, GraphDispatcher
 from torch.utils.data import DataLoader
+
+from ppq.scheduler.perseus import Perseus
 
 from .setting import *
 
@@ -139,6 +141,18 @@ def load_caffe_graph(prototxt_path: str, caffemodel_path: str) -> BaseGraph:
     """
     ppq_ir = load_graph(file_path=prototxt_path, caffemodel_path=caffemodel_path, from_framework=NetworkFramework.CAFFE)
     return format_graph(graph=ppq_ir)
+
+def load_native_graph(import_file: str) -> BaseGraph:
+    """
+        从一个指定位置加载 原生计算图，原生计算图中包含了所有量化与调度信息
+        load native graph from the specified location
+    Args:
+        import_file (str): 计算图的保存位置 the specified location
+
+    Returns:
+        BaseGraph: 解析获得的 ppq 计算图对象 the parsed ppq IR graph
+    """
+    return load_graph(import_file, from_framework=NetworkFramework.NATIVE)
 
 def dump_torch_to_onnx(
     model: torch.nn.Module,
@@ -645,32 +659,18 @@ def format_graph(graph: BaseGraph) -> BaseGraph:
 
 
 def dispatch_graph(graph: BaseGraph, platform: TargetPlatform, setting: QuantizationSetting) -> BaseGraph:
-    """这个函数执行图切分与调度，你的计算图将被切分成一系列子图，并被调度到不同设备上。 调度的逻辑分为自动控制的部分以及手动覆盖的部分，你可以使用
-    QuantizationSetting 来向这个函数传递手动调度表 从而覆盖 PPQ 的调度逻辑。
+    """这个函数执行图切分与调度，你的计算图将被切分成一系列子图，并被调度到不同设备上。 
+    调度的逻辑分为自动控制的部分以及手动覆盖的部分，你可以使用 QuantizationSetting 来向这个函数传递手动调度表 从而覆盖 PPQ 的调度逻辑。
 
-    注意：这个函数依据调度器和TargetPlatform 平台的不同而产生行为差异，生成不同的调度计划。
+    注意：这个函数依据调度器和 TargetPlatform 平台的不同而产生行为差异，生成不同的调度计划。
 
     This function will cut your graph into a series of subgraph and send them to different device.
     PPQ provides an automatic dispatcher which, will generate different dispatching scheme on your TargetPlatform.
     A dispatching table can be passed via QuantizationSetting to override
         the default dispatching logic of ppq dispatcher manually.
     """
-    assert platform in QUANTIZER_COLLECTION, (
-        f'Platform misunderstood, except one of following platform {QUANTIZER_COLLECTION.keys()}')
-    quantizer = QUANTIZER_COLLECTION[platform](graph) # 初始化一个 quantizer 没有很大代价...
-
-    if str(setting.dispatcher).lower() not in DISPATCHER_TABLE:
-        raise ValueError(f'Can not found dispatcher type "{setting.dispatcher}", check your input again.')
-    dispatcher = DISPATCHER_TABLE[str(setting.dispatcher).lower()]()
-    assert isinstance(dispatcher, GraphDispatcher)
-    assert isinstance(quantizer, BaseQuantizer)
-    quant_types = quantizer.quant_operation_types
-
-    dispatching_table = dispatcher.dispatch(
-        graph=graph, quant_types=quant_types,
-        quant_platform=TargetPlatform.UNSPECIFIED, # MUST BE UNSPECIFIED, 这里的意思是交由 Quantizer 决定是否量化这个算子
-        fp32_platform=TargetPlatform.FP32,
-        SOI_platform=TargetPlatform.SHAPE_OR_INDEX)
+    dispatcher = Perseus(graph=graph)
+    dispatching_table = dispatcher.dispatch()
 
     # override dispatching result with setting
     dispatching_override = setting.dispatching_table
@@ -690,6 +690,7 @@ def dispatch_graph(graph: BaseGraph, platform: TargetPlatform, setting: Quantiza
     # insert necessary device switchers.
     formatter = GraphDeviceSwitcher(graph)
     formatter(GraphCommand(GraphCommandType.INSERT_SWITCHER))
+    graph.set_extension_attrib(IS_DISPATCHED_GRAPH, True)
     return graph
 
 
@@ -923,7 +924,7 @@ class ENABLE_CUDA_KERNEL:
     memory cost.
     """
     def __init__(self) -> None:
-        ppq_warning('PPQ is compling CUDA Kernels. Please wait...'
+        ppq_warning('PPQ is compling CUDA Kernels. Please wait...\n'
                     'If there is any problem with kernel compilation, '
                     'feel free to remove ENABLE_CUDA_KERNEL clause.')
         self._state = False
@@ -1028,7 +1029,7 @@ def register_network_exporter(exporter: type, platform: TargetPlatform):
 
 __all__ = ['load_graph', 'load_onnx_graph', 'load_caffe_graph',
            'dispatch_graph', 'dump_torch_to_onnx', 'quantize_onnx_model',
-           'quantize_torch_model', 'quantize_caffe_model',
+           'quantize_torch_model', 'quantize_caffe_model', 'load_native_graph',
            'export_ppq_graph', 'format_graph', 'quantize', 'export',
            'UnbelievableUserFriendlyQuantizationSetting', 'manop',
            'quantize_native_model', 'ENABLE_CUDA_KERNEL', 'DISABLE_CUDA_KERNEL',

--- a/ppq/api/setting.py
+++ b/ppq/api/setting.py
@@ -452,7 +452,7 @@ class QuantizationSettingFactory:
     def pplcuda_setting() -> QuantizationSetting:
         default_setting = QuantizationSetting()
         default_setting.equalization = False
-        default_setting.fusion_setting.fuse_conv_add = False
+        default_setting.fusion_setting.fuse_conv_add = True
         return default_setting
 
     @ staticmethod
@@ -492,6 +492,7 @@ class QuantizationSettingFactory:
     def trt_setting() -> QuantizationSetting:
         default_setting = QuantizationSetting()
         default_setting.fusion = False # 我也不知道对不对
+        default_setting.dispatcher = 'pointwise'
         return default_setting
 
     @ staticmethod

--- a/ppq/core/__init__.py
+++ b/ppq/core/__init__.py
@@ -53,13 +53,22 @@ PPQ.core contains most of PPQ internal abstractions(data structures).
 Do not modify codes within this directory if not necessary.
 """
 
-from .quant   import *
-from .data    import *
-from .defs    import *
-from .storage import *
-from .config  import *
-from .common  import *
+from .common import *
+from .config import PPQ_CONFIG
+from .data import (DataType, OperationMeta, TensorMeta, convert_any_to_numpy,
+                   convert_any_to_python_primary_type, convert_any_to_string,
+                   convert_any_to_torch_tensor, convert_primary_type_to_list)
+from .defs import (SingletonMeta, empty_ppq_cache, ppq_debug_function,
+                   ppq_file_io, ppq_info, ppq_legacy,
+                   ppq_quant_param_computing_function, ppq_warning)
 from .ffi import CUDA
+from .quant import (ChannelwiseTensorQuantizationConfig, NetworkFramework,
+                    OperationQuantizationConfig, QuantizationPolicy,
+                    QuantizationProperty, QuantizationStates, RoundingPolicy,
+                    TargetPlatform, TensorQuantizationConfig)
+from .storage import (Serializable, ValueState, is_file_exist,
+                      open_txt_file_from_writing)
+from typing import Any, Callable, List, Iterable, Set, Dict, Union, Text
 
 print("""
       ____  ____  __   ____                    __              __

--- a/ppq/core/common.py
+++ b/ppq/core/common.py
@@ -4,16 +4,23 @@
 
 
 # Observer 中，最小 scale 限制，所有小于该值的 scale 将被该值覆盖
-OBSERVER_MIN_SCALE = 1e-7
+OBSERVER_MIN_SCALE = 1e-8
+
+OBSERVER_MIN_SCALE_MANUL_OVERRIDE = 'OBSERVER_MIN_SCALE_MANUL_OVERRIDE'
+# 当出现 scale < min_scale 的情况时，是否给出警报 
+OBSERVER_WARNING = False
 # Observer 中 kl 散度的计算设备
 OBSERVER_KL_COMPUTING_DEVICE = 'cpu'
 # Observer 中 hist 箱子的个数
 OBSERVER_KL_HIST_BINS = 8192
+# Observer 中 hist 箱子的属性
+OBSERVER_KL_HIST_BINS_MANUL_OVERRIDE = 'OBSERVER_KL_HIST_BINS_MANUL_OVERRIDE'
 # Observer 中 percentile 的参数
 OBSERVER_PERCENTILE = 0.9999
+# Observer 中 percentile 参数的属性
+OBSERVER_PERCENTILE_MANUL_OVERRIDE = 'OBSERVER_PERCENTILE_MANUL_OVERRIDE'
 # Observer 中 mse 校准方法 hist 箱子的个数
 OBSERVER_MSE_HIST_BINS = 8192
-
 
 # PPLCUDA 中所有需要与 Conv 融合的激活函数
 PPLCUDA_ACTIVATIONS = {'Clip', 'LeakyRelu', 'Relu', 'Sigmoid'}
@@ -63,3 +70,16 @@ CAFFE_DOMAIN = 'ppq.caffe'
 DEFAULT_OPSET_DOMAIN  = 'ai.onnx'
 DEFAULT_OPSET_VERSION = 11
 STRICT_OPSET_CHECKING = False
+
+# 导出 qdq 节点时是否需要导出状态已经是 overlap 的节点
+EXPORT_OVERLAPPED_CONFIG = True
+
+# LSTM 算子的权重缓存属性
+LSTM_FLATTEN_WEIGHT_ATTRIB = 'LSTM_FLATTEN_WEIGHT_ATTRIB'
+# GRU 算子的权重缓存属性
+GRU_FLATTEN_WEIGHT_ATTRIB  = 'GRU_FLATTEN_WEIGHT_ATTRIB'
+
+# 一个属性标记计算图是否已经被调度
+IS_DISPATCHED_GRAPH = 'IS_DISPATCHED_GRAPH'
+# 图上用于表示 Opset 的属性
+GRAPH_OPSET_ATTRIB = 'GRAPH_OPSET'

--- a/ppq/core/config.py
+++ b/ppq/core/config.py
@@ -7,7 +7,7 @@ class PPQ_GLOBAL_CONFIGURATION:
         self.NAME                     = 'PPL Quantization Tool'
         
         # PPQ 的版本号
-        self.VERSION                  = '0.6.4'
+        self.VERSION                  = '0.6.5'
         
         # 导出图时是否导出权重（仅影响 Native 格式导出）
         self.DUMP_VALUE_WHEN_EXPORT   = True

--- a/ppq/core/ffi.py
+++ b/ppq/core/ffi.py
@@ -228,6 +228,14 @@ class CUDA:
             tensor, dy, scales, offsets, minimum, maximum, channel_axis, rounding)
 
     @ staticmethod
+    def OrderPreservingObserve(
+        tensor: torch.Tensor,
+    ) -> torch.Tensor:
+        if not tensor.is_contiguous(): tensor = tensor.contiguous()
+        return __CUDA_EXTENTION__.RoundingLoss_LC_B(tensor)
+
+
+    @ staticmethod
     def Sync():
         """Synchronize device."""
         synchronize()

--- a/ppq/core/storage.py
+++ b/ppq/core/storage.py
@@ -87,16 +87,18 @@ class ValueState(Serializable):
             return None
         elif self._value_type == str('ndarray'):
             value = pickle.loads(self._value)
-            # value = np.frombuffer(self._value, dtype=self._dtype)
+            assert isinstance(value, np.ndarray)
+            value = value.astype(self._dtype)
             value = value.reshape(self._shape)
             return value
         elif self._value_type == str('Tensor'):
             if self._value is not None:
                 value = pickle.loads(self._value)
-                # value = np.frombuffer(self._value, dtype=self._dtype)
+                assert isinstance(value, np.ndarray)
+                value = value.astype(self._dtype)
                 if value is not None:
                     value = value.reshape(self._shape)
-                return convert_any_to_torch_tensor(value, device='cpu')
+                value = convert_any_to_torch_tensor(value, device='cpu')
             else:
                 return torch.tensor([], device='cpu')
         elif self._value_type in {'list', 'tuple', 'dict'}:

--- a/ppq/core/storage.py
+++ b/ppq/core/storage.py
@@ -98,7 +98,10 @@ class ValueState(Serializable):
                 value = value.astype(self._dtype)
                 if value is not None:
                     value = value.reshape(self._shape)
-                value = convert_any_to_torch_tensor(value, device='cpu')
+                value = convert_any_to_torch_tensor(
+                    value, device='cpu', 
+                    dtype=DataType.to_torch(DataType.convert_from_numpy(self._dtype)))
+                return value
             else:
                 return torch.tensor([], device='cpu')
         elif self._value_type in {'list', 'tuple', 'dict'}:

--- a/ppq/csrc/cuda/common.h
+++ b/ppq/csrc/cuda/common.h
@@ -1,0 +1,6 @@
+# include <math.h>
+# include <iostream>
+# include <vector>
+
+using std::vector;
+using int64 = long long;

--- a/ppq/csrc/cuda/export.cc
+++ b/ppq/csrc/cuda/export.cc
@@ -19,4 +19,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("RoundingLoss_LC", RoundingLoss_LC, "RoundingLoss_LC");
     m.def("RoundingLoss_LT_B", RoundingLoss_LT_B, "RoundingLoss_LT_B");
     m.def("RoundingLoss_LC_B", RoundingLoss_LC_B, "RoundingLoss_LC_B");
+
+    m.def("Isotone_T", Isotone_T, "Isotone_T");
 }

--- a/ppq/csrc/cuda/isotone.cpp
+++ b/ppq/csrc/cuda/isotone.cpp
@@ -1,0 +1,57 @@
+# include "isotone.h"
+
+namespace PPQ_Crt{
+
+float SolveIsotoneScale(
+    const float *first_largest_arr, 
+    const float *second_largest_arr, 
+    const int64 length, const int quant_max){
+    /**
+     * @brief 求解保序量化参数，复杂度为0(n^2)
+     * n 为 batch 数量，可以进一步优化到O(n log n)
+     * 不过看起来一般并没有那么多 batch 需要处理
+     * 
+     * Solving isotonic quantization scale
+     * Algorithm Complexity is 0(n^2), where n denotes the num of batches
+     * This can be optimized further to reach O(n log n) complexity.
+     */
+    float *candidates = new float[length * 2];
+    float *s_maxs = new float[length];
+    float *s_mins = new float[length];
+
+    for(int64 i = 0; i < length; i++){
+        auto f = first_largest_arr[i];
+        auto s = second_largest_arr[i];
+        float s_min = s / (quant_max - 1);
+        float s_max = 2 * (f - s);
+
+        s_maxs[i] = s_max;
+        s_mins[i] = s_min;
+
+        candidates[2 * i] = s_min;
+        candidates[2 * i + 1] = s_max;
+    }
+
+    int64 best_satisified = 0;
+    float best_scale      = 1.0f;
+
+    for(int64 i = 0; i < length * 2; i++){
+        auto c = candidates[i]; int64 satisified = 0;
+        for(int64 j = 0; j < length; j++){
+            float s_max = s_maxs[j];
+            float s_min = s_mins[j];
+            satisified += (c <= s_max) + (c >= s_min);
+        }
+        if (satisified > best_satisified){
+            best_satisified = satisified;
+            best_scale = c;
+        }
+    }
+
+    delete [] candidates;
+    delete [] s_maxs;
+    delete [] s_mins;
+    return best_scale;
+}
+
+} // end of namespace

--- a/ppq/csrc/cuda/isotone.h
+++ b/ppq/csrc/cuda/isotone.h
@@ -1,0 +1,6 @@
+# include "common.h"
+
+float SolveIsotoneScale(
+    const float *first_largest_arr, 
+    const float *second_largest_arr, 
+    const int64 length, const int quant_max);

--- a/ppq/csrc/cuda/sort.cu
+++ b/ppq/csrc/cuda/sort.cu
@@ -21,7 +21,7 @@ static void _Quantile_T(
 
 
 __global__
-static void _cuda_order_preserving_observe(
+static void _Isotone_T(
     const float *source,
     float *dest,
     const int64_t num_of_elements
@@ -58,8 +58,7 @@ __host__ Tensor Quantile_T(const Tensor &source, const float q){
     return dest;
 }
 
-
-Tensor cuda_order_preserving_observe(Tensor &source){
+Tensor Isotone_T(const Tensor &source){
     const int num_of_elements = source.numel();
 
     Tensor dest = at::empty({4}, source.options());
@@ -69,7 +68,7 @@ Tensor cuda_order_preserving_observe(Tensor &source){
     float *dest_ptr   = dest.data_ptr<float>();
 
     thrust::sort(thrust::device, source_ptr, source_ptr + num_of_elements);
-    _cuda_order_preserving_observe<<<1, 1>>>(source_ptr, dest_ptr, num_of_elements);
+    _Isotone_T<<<1, 1>>>(source_ptr, dest_ptr, num_of_elements);
     return dest;
 }
 

--- a/ppq/csrc/cuda/sort.h
+++ b/ppq/csrc/cuda/sort.h
@@ -14,3 +14,5 @@ void Histogram_C(
     const float hist_scale,
     const bool clip_outliers,
     Tensor &hist);
+
+Tensor Isotone_T(const Tensor &source);

--- a/ppq/executor/base.py
+++ b/ppq/executor/base.py
@@ -55,9 +55,6 @@ def register_operation_handler(handler: Callable, operation_type: str, platform:
     """
     if platform not in GLOBAL_DISPATCHING_TABLE:
         raise ValueError('Unknown Platform detected, Please check your platform setting.')
-    if operation_type in GLOBAL_DISPATCHING_TABLE[platform]:
-        raise ValueError(f'Platform: {platform.name}, operation type: {operation_type} \
-            already been registered in dispatching table')
     GLOBAL_DISPATCHING_TABLE[platform][operation_type] = handler
 
 

--- a/ppq/executor/op/torch/base.py
+++ b/ppq/executor/op/torch/base.py
@@ -108,6 +108,12 @@ def ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op: Operation, values: List[torch.Tensor],
     if any([devices[0] != d for d in devices]):
         raise ValueError(f'Input tensors do not share a same device. ({[d for d in devices]})')
 
+def GET_VALUE_FROM_INPUTS(values: list, idx: int) -> torch.Tensor:
+    assert isinstance(idx, int)
+    assert idx > 0
+    if len(values) > idx: return values[idx]
+    else: return None
+
 def ASSERT_IS_QUANT_OP(op: QuantableOperation):
     if not isinstance(op, QuantableOperation):
         raise TypeError(f'Given Operation is expected as a QuantableOperation, however {type(op)} was given.')

--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -5,6 +5,7 @@ from typing import List
 import numpy as np
 from ppq.core import DataType, convert_any_to_python_primary_type
 from ppq.IR import Operation
+from ppq.core.common import GRU_FLATTEN_WEIGHT_ATTRIB, LSTM_FLATTEN_WEIGHT_ATTRIB
 from ppq.log import NaiveLogger
 from ppq.utils import process_attribute
 
@@ -19,6 +20,47 @@ from .base import *
 # torch func: https://pytorch.org/docs/stable/nn.functional.html
 
 logger = NaiveLogger.get_logger('PPQ')
+
+
+def _onnx_padding_to_torch(pads: List[int]) -> List[int]:
+    # Convert padding from onnx format to torch format
+    # onnx format: [x1_begin, x2_begin, ... , x1_end, x2_end, ...]
+    # torch format [xn_begin, xn_end, ... , x2_begin, x2_end, x1_begin, x1_end]
+    middle = len(pads) // 2
+    onnx_pad_begin, onnx_pad_end = pads[:middle], pads[middle:]
+    onnx_pad_begin, onnx_pad_end = onnx_pad_begin[::-1], onnx_pad_end[::-1]
+    torch_pads = []
+    for begin, end in zip(onnx_pad_begin, onnx_pad_end):
+        torch_pads.extend([begin, end])
+
+    return torch_pads
+
+
+def Abs_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    """Absolute takes one input data (Tensor) and produces one output data (Tensor) 
+    where the absolute is, y = abs(x), is applied to the tensor elementwise.
+
+    Inputs
+        X (differentiable) : T
+            Input tensor
+    
+    Outputs
+        Y (differentiable) : T
+            Output tensor
+
+    Args:
+        op (Operation): _description_
+        values (List[torch.Tensor]): _description_
+        ctx (TorchBackendContext, optional): _description_. Defaults to None.
+
+    Returns:
+        torch.Tensor: _description_
+    """
+    ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
+    [x] = values
+    return x.abs()
+
 
 def Conv_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     """The convolution operator consumes an input tensor and a filter, and
@@ -107,28 +149,54 @@ def Conv_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendCon
     """
     ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=2, max_num_of_input=3)
-    process_attribute(op.attributes, values[0].shape[2:], values[1].shape[2:])
 
     groups    = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='group', default=1)
     padding   = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='pads', default=0)
     dilation  = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='dilations', default=1)
     stride    = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='strides', default=1)
+    auto_pad  = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='auto_pad', default='NOTSET')
 
     x, w = values[: 2]
     b = values[2] if len(values) > 2 else None
 
-    # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
-    if isinstance(padding, list) and len(padding) == 4:
-        p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
-        # torch does not support padding contains 4 value, there is a fix of it.
-        if p_left == p_right and p_top == p_bottom:
-            padding = [p_top, p_left]
-        else:
-            x = F.pad(x, pad=[p_left, p_right, p_top, p_bottom])
-            padding = 0
+    ndim = w.ndim
+    # conv - 1d
+    if ndim in {2, 3}:
+        if auto_pad != 'NOTSET':
+            raise NotImplementedError(f'auto_pad must be "NOTSET" with 1-d conv {op.name}')
+        x = F.pad(x, padding)
+        output = F.conv1d(
+            input=x, weight=w, bias=b, groups=groups,
+            dilation=dilation, stride=stride)
 
-    output = F.conv2d(input=x, weight=w, bias=b, groups=groups, padding=padding,
-                      dilation=dilation, stride=stride)
+    # conv - 2d
+    elif ndim == 4:
+        process_attribute(op.attributes, values[0].shape[2:], values[1].shape[2:])
+        # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
+        if isinstance(padding, list) and len(padding) == 4:
+            p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
+            # torch does not support padding contains 4 value, there is a fix of it.
+            if p_left == p_right and p_top == p_bottom:
+                padding = [p_top, p_left]
+            else:
+                x = F.pad(x, pad=[p_left, p_right, p_top, p_bottom])
+                padding = 0
+
+        output = F.conv2d(
+            input=x, weight=w, bias=b, groups=groups, padding=padding,
+            dilation=dilation, stride=stride)
+
+    # conv - 3d
+    elif ndim == 5:
+        if auto_pad != 'NOTSET':
+            raise NotImplementedError(f'auto_pad must be "NOTSET" with 3-d conv {op.name}')
+        x = F.pad(x, padding)
+        output = F.conv3d(
+            input=x, weight=w, bias=b, groups=groups,
+            dilation=dilation, stride=stride)
+    
+    else:
+        raise ValueError(f'Operation {op.name} is invalid, input dimension is not supported.')
     return output
 
 
@@ -241,20 +309,39 @@ def ConvTranspose_forward(op: Operation, values: List[torch.Tensor], ctx: TorchB
 
     x, w = values[:2]
     b = values[2] if len(values) > 2 else None
+    ndim = x.ndim
 
-    # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
-    if isinstance(padding, list) and len(padding) == 4:
-        p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
-        # torch does not support padding contains 4 value, there is a fix of it.
-        if p_left == p_right and p_top == p_bottom:
-            padding = [p_top, p_left]
-        else:
-            x = F.pad(x, pad=[p_left, p_right, p_top, p_bottom])
-            padding = 0
+    # 2d conv transpose
+    if ndim == 4:
+        # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
+        if isinstance(padding, list) and len(padding) == 4:
+            p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
+            # torch does not support padding contains 4 value, there is a fix of it.
+            if p_left == p_right and p_top == p_bottom:
+                padding = [p_top, p_left]
+            else:
+                x = F.pad(x, pad=[p_left, p_right, p_top, p_bottom])
+                padding = 0
 
-    output = F.conv_transpose2d(
-        input=x, weight=w, bias=b, groups=groups, padding=padding,
-        dilation=dilation, stride=stride, output_padding=output_padding)
+        output = F.conv_transpose2d(
+            input=x, weight=w, bias=b, groups=groups, padding=padding,
+            dilation=dilation, stride=stride, output_padding=output_padding)
+
+    # 1d conv transpose
+    elif ndim in {2, 3}:
+        x = F.pad(x, _onnx_padding_to_torch(padding))
+        output = F.conv_transpose1d(
+            input=x, weight=w, bias=b, groups=groups,
+            dilation=dilation, stride=stride, output_padding=output_padding)
+
+    elif ndim == 5:
+        x = F.pad(x, _onnx_padding_to_torch(padding))
+        output = F.conv_transpose3d(
+            input=x, weight=w, bias=b, groups=groups,
+            dilation=dilation, stride=stride, output_padding=output_padding)
+    
+    else:
+        raise ValueError(f'Operation {op.name} is invalid, input dimension is not supported.')
     return output
 
 
@@ -263,32 +350,48 @@ def MaxPool2d_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBacke
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
     process_attribute(op.attributes, values[0].shape[2:])
 
-    [input_value] = values
+    [x] = values
     padding   = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='pads', default=0)
     dilation  = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='dilations', default=1)
     stride    = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='strides', default=None)
     ceil_mode = bool(GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='ceil_mode', default=False))
-
-    # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
-    if isinstance(padding, list) and len(padding) == 4:
-        p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
-        # torch does not support padding contains 4 value, there is a fix of it.
-        if p_left == p_right and p_top == p_bottom:
-            padding = [p_top, p_left]
-        else:
-            input_value = F.pad(input_value, pad=[p_left, p_right, p_top, p_bottom])
-            padding = 0
-
-    if op.type == 'GlobalMaxPool': kernel_size = input_value.size()[-2:]
+    if op.type == 'GlobalMaxPool': kernel_size = x.size()[-2:]
     else: kernel_size = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='kernel_shape', compulsive=True)
 
-    output = F.max_pool2d(input_value, kernel_size=kernel_size,
-                          padding=padding, dilation=dilation,
-                          stride=stride, ceil_mode=ceil_mode)
+    ndim = x.ndim
+    # pool - 3d
+    if ndim == 5:
+        x = F.pad(x, _onnx_padding_to_torch(padding), value=float("-inf"))
+        output = F.max_pool3d(
+            x, kernel_size=kernel_size,
+            dilation=dilation, stride=stride, ceil_mode=ceil_mode)
+
+    elif ndim == 4:
+        # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
+        if isinstance(padding, list) and len(padding) == 4:
+            p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
+            # torch does not support padding contains 4 value, there is a fix of it.
+            if p_left == p_right and p_top == p_bottom:
+                padding = [p_top, p_left]
+            else:
+                x = F.pad(x, pad=_onnx_padding_to_torch(padding), value=float("-inf"))
+                padding = 0
+
+        output = F.max_pool2d(
+            x, kernel_size=kernel_size,
+            padding=padding, dilation=dilation,
+            stride=stride, ceil_mode=ceil_mode)
+
+    if ndim in {2, 3}:
+        x = F.pad(x, _onnx_padding_to_torch(padding), value=float("-inf"))
+        output = F.max_pool1d(
+            x, kernel_size=kernel_size,
+            dilation=dilation, stride=stride, ceil_mode=ceil_mode)
+    else:
+        raise ValueError(f'Operation {op.name} is invalid, input dimension is not supported.')
     return output
 
 
-# noinspection PyCallingNonCallable
 def BatchNormalization_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=5, max_num_of_input=5)
     input_data, weight, bias, running_mean, running_var = values
@@ -334,24 +437,10 @@ def Mul_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendCont
 
 
 def MultiHeadAttention_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
-    """Perform MultiHeadAttetion opr forward.
-
-    Args:
-        op (Operation): MultiHeadAttention
-        values (List[torch.Tensor]): opr inputs
-        ctx (TorchBackendContext, optional): Context. Defaults to None.
-
-    Raises:
-        NotImplementedError: In [Vit Paper](https://arxiv.org/abs/2010.11929), MultiHeadAttention inputs are actually the same tensor, we suppose that this would **not** be simplified.
-        ValueError: MultiHeadAttention contains `embed_dim` and `num_heads`.
-
-    Returns:
-        list: opr output and internal result for quantization.
-    """
     if len(values) != 11:
         raise NotImplementedError('Not implement simplified MultiHeadAttention')
 
-    q_in,k_in,v_in,q_w,q_b,k_w,k_b,v_w,v_b,o_w,o_b = values
+    q,k,v,q_w,q_b,k_w,k_b,v_w,v_b,o_w,o_b = values
     embed_dim = op.attributes.get('embed_dim')
     num_heads = op.attributes.get('num_heads')
 
@@ -359,27 +448,21 @@ def MultiHeadAttention_forward(op: Operation, values: List[torch.Tensor], ctx: T
         raise ValueError('Cannot fetch embed_dim or num_heads')
 
     # setup parameters
-    batch_size = q_in.shape[0]
+    batch_size = q.shape[0]
     head_dim = embed_dim // num_heads
     scale = head_dim ** -0.5
 
-    xq = F.linear(q_in, q_w, q_b)
-    xk = F.linear(k_in, k_w, k_b)
-    xv = F.linear(v_in, v_w, v_b)
-    
-    B, N, _ = xq.shape
-    
-    q = xq.reshape(B, N, num_heads, head_dim).permute(0, 2, 1, 3)
-    k = xk.reshape(B, N, num_heads, head_dim).permute(0, 2, 1, 3)
-    v = xv.reshape(B, N, num_heads, head_dim).permute(0, 2, 1, 3)
+    q = F.linear(q, q_w, q_b)
+    k = F.linear(k, k_w, k_b)
+    v = F.linear(v, v_w, v_b)
 
     energy = (q @ k.transpose(-2, -1)) * scale
     attn = energy.softmax(dim=-1)
 
-    feat = (attn @ v).transpose(1, 2).reshape(batch_size, -1, embed_dim)
-    out = F.linear(feat, o_w, o_b)
-    
-    return out
+    x = (attn @ v).transpose(1, 2).reshape(batch_size, -1, embed_dim)
+    x = F.linear(x, o_w, o_b)
+
+    return x
 
 
 def Add_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
@@ -412,6 +495,7 @@ def Add_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendCont
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=2, max_num_of_input=2)
     a, b = values
     return a + b
+
 
 def And_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
@@ -500,26 +584,38 @@ def AveragePool_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBac
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
     process_attribute(op.attributes, values[0].shape[2:])
 
-    [input_value] = values
+    [x] = values
     padding   = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='pads', default=0)
     stride    = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='strides', default=None)
     ceil_mode = bool(GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='ceil_mode', default=False))
-
-    # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
-    if isinstance(padding, list) and len(padding) == 4:
-        p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
-        # torch does not support padding contains 4 value, there is a fix of it.
-        if p_left == p_right and p_top == p_bottom:
-            padding = [p_top, p_left]
-        else:
-            input_value = F.pad(input_value, pad=[p_left, p_right, p_top, p_bottom])
-            padding = 0
-
-    if op.type == 'GlobalAveragePool': kernel_size = input_value.size()[-2:]
+    if op.type == 'GlobalAveragePool': kernel_size = x.size()[-2:]
     else: kernel_size = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='kernel_shape', compulsive=True)
+    
+    ndim = x.ndim
+    # pool 2d
+    if ndim == 4:
+        # onnx pads format[top, left, bottom, right] to torch pads format[left, right, top, bottom]
+        if isinstance(padding, list) and len(padding) == 4:
+            p_left, p_right, p_top, p_bottom = padding[1], padding[3], padding[0], padding[2]
+            # torch does not support padding contains 4 value, there is a fix of it.
+            if p_left == p_right and p_top == p_bottom:
+                padding = [p_top, p_left]
+            else:
+                x = F.pad(x, pad=[p_left, p_right, p_top, p_bottom])
+                padding = 0
 
-    output = F.avg_pool2d(input_value, kernel_size=kernel_size,
-                          padding=padding, stride=stride, ceil_mode=ceil_mode)
+        output = F.avg_pool2d(
+            x, kernel_size=kernel_size,
+            padding=padding, stride=stride, ceil_mode=ceil_mode)
+    # pool 3d
+    elif ndim == 5:
+        x = F.pad(x, padding)
+        output = F.avg_pool3d(
+            x, kernel_size=kernel_size,
+            stride=stride, ceil_mode=ceil_mode)
+    else:
+        raise ValueError(f'Operation {op.name} is invalid, input dimension is not supported.')
+    
     return output
 
 
@@ -730,9 +826,14 @@ def Squeeze_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackend
     else:
         ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
         ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
-        [squeezing_tensor], axes = values, GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='axes', compulsive=True)
+        [squeezing_tensor], axes = values, GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='axes', compulsive=False, default=None)
     
     # common part
+    if axes is None:
+        axes = []
+        shape = squeezing_tensor.shape
+        for dim, s in enumerate(shape):
+            if s == 1: axes.append(dim)
     if isinstance(axes, list):
         for squeezing_dim in sorted(axes, reverse=True):
             squeezing_tensor = torch.squeeze(squeezing_tensor, squeezing_dim)
@@ -1674,18 +1775,16 @@ def Pad_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendCont
     if isinstance(pads, torch.Tensor):
         assert pads.device.type == 'cpu', 'Oops'
         pads = pads.tolist()
-
-    if len(pads) == 2:
-        pads = [0, 0, pads[0], pads[1]]
-    elif len(pads) == 4:
-        pads = [pads[1], pads[3], pads[0], pads[2]]
-    elif len(pads) == 8:  # inception v3, i don't known if the order is correct.
-        pads = [pads[3], pads[7], pads[2], pads[6]]
+    pads = _onnx_padding_to_torch(pads)
 
     if mode == 'constant':
         constant_value = values[-1] if len(values) == 3 else 0
         output = F.pad(input_data, pads, mode, constant_value)
     elif mode == 'reflect':
+        output = input_data
+        while len(pads) > 4:
+            output = F.pad(input_data, pads[-4:], mode)
+            pads   = pads[: -4]
         output = F.pad(input_data, pads, mode)
     elif mode == 'edge':
         output = F.pad(input_data, pads, 'replicate')
@@ -1989,215 +2088,515 @@ def HardSwish_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBacke
 def GRU_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     """Computes an one-layer GRU. This operator is usually supported via some
     custom implementation such as CuDNN.
-
     只支持 pytorch 导出来的 GRU 啊亲; 必须要 6 个输入 Variable
-
     Notations:
-
         X - input tensor
-
         z - update gate
-
         r - reset gate
-
         h - hidden gate
-
         t - time step (t-1 means previous time step)
-
         W[zrh] - W parameter weight matrix for update, reset, and hidden gates
-
         R[zrh] - R recurrence weight matrix for update, reset, and hidden gates
-
         Wb[zrh] - W bias vectors for update, reset, and hidden gates
-
         Rb[zrh] - R bias vectors for update, reset, and hidden gates
-
         WB[zrh] - W parameter weight matrix for backward update, reset, and hidden gates
-
         RB[zrh] - R recurrence weight matrix for backward update, reset, and hidden gates
-
         WBb[zrh] - W bias vectors for backward update, reset, and hidden gates
-
         RBb[zrh] - R bias vectors for backward update, reset, and hidden gates
-
         H - Hidden state
-
         num_directions - 2 if direction == bidirectional else 1
-
     Activation functions:
-
         Relu(x)                - max(0, x)
-
         Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
-
         Sigmoid(x)             - 1/(1 + e^{-x})
-
     (NOTE: Below are optional)
-
         Affine(x)              - alpha*x + beta
-
         LeakyRelu(x)           - x if x >= 0 else alpha * x
-
         ThresholdedRelu(x)     - x if x >= alpha else 0
-
         ScaledTanh(x)          - alpha*Tanh(beta*x)
-
         HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
-
         Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
-
         Softsign(x)            - x/(1 + |x|)
-
         Softplus(x)            - log(1 + e^x)
-
     Equations (Default: f=Sigmoid, g=Tanh):
-
         - zt = f(Xt*(Wz^T) + Ht-1*(Rz^T) + Wbz + Rbz)
-
         - rt = f(Xt*(Wr^T) + Ht-1*(Rr^T) + Wbr + Rbr)
-
         - ht = g(Xt*(Wh^T) + (rt (.) Ht-1)*(Rh^T) + Rbh + Wbh) # default, when linear_before_reset = 0
-
         - ht = g(Xt*(Wh^T) + (rt (.) (Ht-1*(Rh^T) + Rbh)) + Wbh) # when linear_before_reset != 0
-
         - Ht = (1 - zt) (.) ht + zt (.) Ht-1
-
     This operator has optional inputs/outputs. See the doc for more details about the representation of optional arguments.
     An empty string may be used in the place of an actual argument's name to indicate a missing argument.
     Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
-
     Version
     This version of the operator has been available since version 14 of the default ONNX operator set.
-
     Other versions of this operator: 1, 3, 7
-
     Attributes
         activation_alpha : list of floats
             Optional scaling values used by some activation functions.
             The values are consumed in the order of activation functions,
             for example (f, g, h) in LSTM.
-
             Default values are the same as of corresponding ONNX operators.For example with LeakyRelu,
             the default alpha is 0.01.
-
         activation_beta : list of floats
             Optional scaling values used by some activation functions.
             The values are consumed in the order of activation functions,
             for example (f, g, h) in LSTM.
-
             Default values are the same as of corresponding ONNX operators.
-
         activations : list of strings
             A list of 2 (or 4 if bidirectional) activation functions for update, reset, and hidden gates.
             The activation functions must be one of the activation functions specified above.
             Optional: See the equations for default if not specified.
-
         clip : float
             Cell clip threshold.
             Clipping bounds the elements of a tensor in the range of [-threshold, +threshold]
             and is applied to the input of activations. No clip if not specified.
-
         direction : string (default is forward)
             Specify if the RNN is forward, reverse, or bidirectional.
             Must be one of forward (default), reverse, or bidirectional.
-
         hidden_size : int
             Number of neurons in the hidden layer
-
         layout : int (default is 0)
             The shape format of inputs X, initial_h and outputs Y, Y_h.
-
             If 0, the following shapes are expected:
                 X.shape = [seq_length, batch_size, input_size],
                 Y.shape = [seq_length, num_directions, batch_size, hidden_size],
                 initial_h.shape = Y_h.shape = [num_directions, batch_size, hidden_size].
-
             If 1, the following shapes are expected:
                 X.shape = [batch_size, seq_length, input_size],
                 Y.shape = [batch_size, seq_length, num_directions, hidden_size],
                 initial_h.shape = Y_h.shape = [batch_size, num_directions, hidden_size].
-
         linear_before_reset : int (default is 0)
             When computing the output of the hidden gate,
             apply the linear transformation before multiplying by the output of the reset gate.
-
     Inputs (3 - 6)
         X (differentiable) : T
             The input sequences packed (and potentially padded) into one 3-D tensor with the shape of
             `[seq_length, batch_size, input_size]`.
-
         W (differentiable) : T
             The weight tensor for the gates.
             Concatenation of `W[zrh]` and `WB[zrh]` (if bidirectional) along dimension 0.
             This tensor has shape `[num_directions, 3*hidden_size, input_size]`.
-
         R (differentiable) : T
             The recurrence weight tensor.
             Concatenation of `R[zrh]` and `RB[zrh]` (if bidirectional) along dimension 0.
             This tensor has shape `[num_directions, 3*hidden_size, hidden_size]`.
-
         B (optional, differentiable) : T
             The bias tensor for the gates.
             Concatenation of `[Wb[zrh], Rb[zrh]]` and `[WBb[zrh], RBb[zrh]]` (if bidirectional) along dimension 0.
             This tensor has shape `[num_directions, 6*hidden_size]`. Optional: If not specified - assumed to be 0
-
         sequence_lens (optional, non-differentiable) : T1
             Optional tensor specifying lengths of the sequences in a batch.
             If not specified - assumed all sequences in the batch to have length `seq_length`.
             It has shape `[batch_size]`.
-
         initial_h (optional, non-differentiable) : T
             Optional initial value of the hidden.
             If not specified - assumed to be 0.
             It has shape `[num_directions, batch_size, hidden_size]`.
-
     Outputs (0 - 2)
         Y (optional, differentiable) : T
             A tensor that concats all the intermediate output values of the hidden.
             It has shape `[seq_length, num_directions, batch_size, hidden_size]`.
-
         Y_h (optional, differentiable) : T
             The last output value of the hidden.
             It has shape `[num_directions, batch_size, hidden_size]`.
-
     Type Constraints
         T : tensor(float16), tensor(float), tensor(double)
-
     Constrain input and output types to float tensors.
         T1 : tensor(int32)
-
     Constrain seq_lens to integer tensor.
     """
-    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=6, max_num_of_input=6)
-    direction = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='direction', default='forward')
-    if direction == 'reverse': raise NotImplementedError('GRU do not support reverse mode now.')
-    if direction == 'bidirectional': raise NotImplementedError('PPQ do not support bidirectional gru now.')
-    linear_before_reset = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='linear_before_reset', default=0)
-    if linear_before_reset == 0: raise NotImplementedError('PPQ do not support linear_before_reset = 0')
-    x, w, r, b, _, h = values
-    num_of_elements = b.numel() // 6
-    # _VF.gru needs following arguments:
-    # input_x, batchsize, hidden_state, flatten_weights, need_bias(bool),
-    # num_of_layer, dropout, is_training(bool), is_bidirectional(bool)
-    w = torch.cat([
-        w[0][num_of_elements * 1: num_of_elements * 2],
-        w[0][num_of_elements * 0: num_of_elements * 1],
-        w[0][num_of_elements * 2: num_of_elements * 3]], dim=0).contiguous()
-    r = torch.cat([
-        r[0][num_of_elements * 1: num_of_elements * 2],
-        r[0][num_of_elements * 0: num_of_elements * 1],
-        r[0][num_of_elements * 2: num_of_elements * 3]], dim=0).contiguous()
-    b1 = torch.cat([
-        b[0, num_of_elements * 1: num_of_elements * 2],
-        b[0, num_of_elements * 0: num_of_elements * 1],
-        b[0, num_of_elements * 2: num_of_elements * 3]]).contiguous()
-    b2 = torch.cat([
-        b[0, num_of_elements * 4: num_of_elements * 5],
-        b[0, num_of_elements * 3: num_of_elements * 4],
-        b[0, num_of_elements * 5: num_of_elements * 6]]).contiguous()
-    hidden_vector, last_state = _VF.gru(
-        x, h, (w, r, b1, b2), True, 1, 0.0, False, False, False)
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=3, max_num_of_input=6)
+    # first 3 are mandatory input
+    x, w, r   = values[: 3]
+    b         = GET_VALUE_FROM_INPUTS(values, 3)
+    seq_len   = GET_VALUE_FROM_INPUTS(values, 4)
+    initial_h = GET_VALUE_FROM_INPUTS(values, 5)
+    
+    # sequence length will be dropped without warrning.
+    # if seq_len is not None: raise NotImplementedError('PPQ do not support LSTM with explicite length.')
+    
+    # check attributes
+    activation_alpha = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='activation_alpha', default=None)
+    activation_beta  = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='activation_beta', default=None)
+    activations      = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='activations', default=None)
+    clip             = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='clip', default=None)
+    direction        = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='direction', default='forward')
+    hidden_size      = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='hidden_size', compulsive=True)
+    linear_before_reset = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='layout', default=0)
+    if linear_before_reset != 0: raise NotImplementedError('PPQ do not support LSTM with linear_before_reset != 1.')
+    if activation_alpha is not None: raise NotImplementedError('PPQ do not support LSTM with cutimized activation.')
+    if activation_beta is not None: raise NotImplementedError('PPQ do not support LSTM with cutimized activation.')
+    if activations is not None: raise NotImplementedError('PPQ do not support LSTM with cutimized activation.')
+
+    # flag
+    bidirectional = (direction == 'bidirectional')
+    has_bias      = (b is not None)
+
+    # create flatten weights:
+    if GRU_FLATTEN_WEIGHT_ATTRIB not in op.attributes:
+        forward_w = torch.cat([
+            w[0][hidden_size * 1: hidden_size * 2],
+            w[0][hidden_size * 0: hidden_size * 1],
+            w[0][hidden_size * 2: hidden_size * 3]], dim=0).contiguous()
+        forward_r = torch.cat([
+            r[0][hidden_size * 1: hidden_size * 2],
+            r[0][hidden_size * 0: hidden_size * 1],
+            r[0][hidden_size * 2: hidden_size * 3]], dim=0).contiguous()
+        if has_bias:
+            forward_bias_1 = torch.cat([
+                b[0, hidden_size * 1: hidden_size * 2],
+                b[0, hidden_size * 0: hidden_size * 1],
+                b[0, hidden_size * 2: hidden_size * 3]]).contiguous()
+            forward_bias_2 = torch.cat([
+                b[0, hidden_size * 4: hidden_size * 5],
+                b[0, hidden_size * 3: hidden_size * 4],
+                b[0, hidden_size * 5: hidden_size * 6]]).contiguous()
+        if bidirectional == True:
+            reverse_w = torch.cat([
+                w[1][hidden_size * 1: hidden_size * 2],
+                w[1][hidden_size * 0: hidden_size * 1],
+                w[1][hidden_size * 2: hidden_size * 3]], dim=0).contiguous()
+            reverse_r = torch.cat([
+                r[1][hidden_size * 1: hidden_size * 2],
+                r[1][hidden_size * 0: hidden_size * 1],
+                r[1][hidden_size * 2: hidden_size * 3]], dim=0).contiguous()
+            if has_bias:
+                reverse_bias_1 = torch.cat([
+                    b[1, hidden_size * 1: hidden_size * 2],
+                    b[1, hidden_size * 0: hidden_size * 1],
+                    b[1, hidden_size * 2: hidden_size * 3]]).contiguous()
+                reverse_bias_2 = torch.cat([
+                    b[1, hidden_size * 4: hidden_size * 5],
+                    b[1, hidden_size * 3: hidden_size * 4],
+                    b[1, hidden_size * 5: hidden_size * 6]]).contiguous()
+
+        flatten_weight = [forward_w, forward_r]
+        if has_bias:                   flatten_weight = [forward_w, forward_r, forward_bias_1, forward_bias_2]
+        if bidirectional:              flatten_weight = [forward_w, forward_r, reverse_w, reverse_r]
+        if bidirectional and has_bias: flatten_weight = [
+            forward_w, forward_r, forward_bias_1, forward_bias_2, reverse_w, reverse_r, reverse_bias_1, reverse_bias_2]
+        op.set_extension_attrib(GRU_FLATTEN_WEIGHT_ATTRIB, flatten_weight)
+    
+    s = 2 if bidirectional else 1
+    if initial_h is None:
+        initial_h = torch.zeros(
+            size=[s, x.shape[1], x.shape[2]], 
+            device=x.device, dtype=torch.float32)
+
+    result = _VF.gru(
+        x,                                       # x
+        initial_h,                               # initial hidden state
+        op._detail[GRU_FLATTEN_WEIGHT_ATTRIB],   # flatten weights
+        has_bias,                                # has bias
+        1,                                       # num of layer
+        0.0,                                     # dropout
+        False,                                   # training flag
+        bidirectional,                           # bidirectional
+        False)                                   # batch first
+
+    hidden_vector, last_state = result
     return hidden_vector.unsqueeze(1), last_state
+
+
+def LSTM_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    """Computes an one-layer LSTM. This operator is usually supported via some
+    custom implementation such as CuDNN.
+
+    只支持 pytorch 导出来的 LSTM 啊亲; 必须要 7 个输入 Variable
+
+    Computes an one-layer LSTM. This operator is usually supported via some custom implementation such as CuDNN.
+
+    Notations:
+
+    X - input tensor
+
+    i - input gate
+
+    o - output gate
+
+    f - forget gate
+
+    c - cell gate
+
+    t - time step (t-1 means previous time step)
+
+    W[iofc] - W parameter weight matrix for input, output, forget, and cell gates
+
+    R[iofc] - R recurrence weight matrix for input, output, forget, and cell gates
+
+    Wb[iofc] - W bias vectors for input, output, forget, and cell gates
+
+    Rb[iofc] - R bias vectors for input, output, forget, and cell gates
+
+    P[iof] - P peephole weight vector for input, output, and forget gates
+
+    WB[iofc] - W parameter weight matrix for backward input, output, forget, and cell gates
+
+    RB[iofc] - R recurrence weight matrix for backward input, output, forget, and cell gates
+
+    WBb[iofc] - W bias vectors for backward input, output, forget, and cell gates
+
+    RBb[iofc] - R bias vectors for backward input, output, forget, and cell gates
+
+    PB[iof] - P peephole weight vector for backward input, output, and forget gates
+
+    H - Hidden state
+
+    num_directions - 2 if direction == bidirectional else 1
+
+    Activation functions:
+
+    Relu(x)                - max(0, x)
+
+    Tanh(x)                - (1 - e^{-2x})/(1 + e^{-2x})
+
+    Sigmoid(x)             - 1/(1 + e^{-x})
+
+    (NOTE: Below are optional)
+
+    Affine(x)              - alpha*x + beta
+
+    LeakyRelu(x)           - x if x >= 0 else alpha * x
+
+    ThresholdedRelu(x)     - x if x >= alpha else 0
+
+    ScaledTanh(x)          - alpha*Tanh(beta*x)
+
+    HardSigmoid(x)         - min(max(alpha*x + beta, 0), 1)
+
+    Elu(x)                 - x if x >= 0 else alpha*(e^x - 1)
+
+    Softsign(x)            - x/(1 + |x|)
+
+    Softplus(x)            - log(1 + e^x)
+    Equations (Default: f=Sigmoid, g=Tanh, h=Tanh):
+
+    - it = f(Xt*(Wi^T) + Ht-1*(Ri^T) + Pi (.) Ct-1 + Wbi + Rbi)
+
+    - ft = f(Xt*(Wf^T) + Ht-1*(Rf^T) + Pf (.) Ct-1 + Wbf + Rbf)
+
+    - ct = g(Xt*(Wc^T) + Ht-1*(Rc^T) + Wbc + Rbc)
+
+    - Ct = ft (.) Ct-1 + it (.) ct
+
+    - ot = f(Xt*(Wo^T) + Ht-1*(Ro^T) + Po (.) Ct + Wbo + Rbo)
+
+    - Ht = ot (.) h(Ct)
+    This operator has optional inputs/outputs. 
+    See the doc for more details about the representation of optional arguments. 
+    An empty string may be used in the place of an actual argument's name to indicate a missing argument. 
+    Trailing optional arguments (those not followed by an argument that is present) may also be simply omitted.
+
+    Version
+    This version of the operator has been available since version 7 of the default ONNX operator set.
+
+    Attributes
+        activation_alpha : list of floats
+            Optional scaling values used by some activation functions. 
+            The values are consumed in the order of activation functions, 
+                for example (f, g, h) in LSTM. 
+    
+            Default values are the same as of corresponding ONNX operators.For example with LeakyRelu, the default alpha is 0.01.
+    
+        activation_beta : list of floats
+            Optional scaling values used by some activation functions. 
+            The values are consumed in the order of activation functions, 
+            for example (f, g, h) in LSTM. 
+            
+            Default values are the same as of corresponding ONNX operators.
+    
+        activations : list of strings
+            A list of 3 (or 6 if bidirectional) activation functions for input, 
+            output, forget, cell, and hidden. 
+            
+            The activation functions must be one of the activation functions specified above. 
+            Optional: See the equations for default if not specified.
+    
+        clip : float
+            Cell clip threshold. Clipping bounds the elements of a tensor in the range of 
+            [-threshold, +threshold] and is applied to the input of activations.
+            No clip if not specified.
+        
+        direction : string (default is forward)
+            Specify if the RNN is forward, reverse, or bidirectional. 
+            Must be one of forward (default), reverse, or bidirectional.
+
+        hidden_size : int
+            Number of neurons in the hidden layer
+    
+        input_forget : int (default is 0)
+            Couple the input and forget gates if 1.
+    
+    Inputs (3 - 8)
+        X : T
+            The input sequences packed (and potentially padded) into one 3-D tensor 
+                with the shape of `[seq_length, batch_size, input_size]`.
+   
+        W : T
+            The weight tensor for the gates. Concatenation of `W[iofc]` and `WB[iofc]` 
+            (if bidirectional) along dimension 0. The tensor has shape `[num_directions, 4*hidden_size, input_size]`.
+    
+        R : T
+            The recurrence weight tensor. Concatenation of `R[iofc]` and `RB[iofc]` (if bidirectional) along dimension 0. 
+            This tensor has shape `[num_directions, 4*hidden_size, hidden_size]`.
+    
+        B (optional) : T
+            The bias tensor for input gate. Concatenation of `[Wb[iofc], Rb[iofc]]`, 
+            and `[WBb[iofc], RBb[iofc]]` (if bidirectional) along dimension 0. 
+            
+            This tensor has shape `[num_directions, 8*hidden_size]`. 
+            Optional: If not specified - assumed to be 0.
+    
+        sequence_lens (optional) : T1
+            Optional tensor specifying lengths of the sequences in a batch. 
+            If not specified - assumed all sequences in the batch to have length `seq_length`. 
+            It has shape `[batch_size]`.
+        
+        initial_h (optional) : T
+            Optional initial value of the hidden. 
+            If not specified - assumed to be 0. 
+            It has shape `[num_directions, batch_size, hidden_size]`.
+    
+        initial_c (optional) : T
+            Optional initial value of the cell. 
+            If not specified - assumed to be 0. 
+            It has shape `[num_directions, batch_size, hidden_size]`.
+    
+        P (optional) : T
+            The weight tensor for peepholes.
+            Concatenation of `P[iof]` and `PB[iof]` (if bidirectional) along dimension 0. 
+            It has shape `[num_directions, 3*hidde_size]`. Optional: If not specified - assumed to be 0.
+    
+    Outputs (0 - 3)
+        Y (optional) : T
+            A tensor that concats all the intermediate output values of the hidden. 
+            It has shape `[seq_length, num_directions, batch_size, hidden_size]`.
+    
+        Y_h (optional) : T
+            The last output value of the hidden. 
+            It has shape `[num_directions, batch_size, hidden_size]`.
+    
+        Y_c (optional) : T
+            The last output value of the cell. 
+            It has shape `[num_directions, batch_size, hidden_size]`.
+    """
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=3, max_num_of_input=8)
+    # first 3 are mandatory input
+    x, w, r   = values[: 3]
+    b         = GET_VALUE_FROM_INPUTS(values, 3)
+    seq_len   = GET_VALUE_FROM_INPUTS(values, 4)
+    initial_h = GET_VALUE_FROM_INPUTS(values, 5)
+    initial_c = GET_VALUE_FROM_INPUTS(values, 6)
+    p         = GET_VALUE_FROM_INPUTS(values, 7)
+    if p is not None: raise NotImplementedError('PPQ do not support LSTM with peepholes.')
+    
+    # sequence length will be dropped without warrning.
+    # if seq_len is not None: raise NotImplementedError('PPQ do not support LSTM with explicite length.')
+
+    # check attributes
+    activation_alpha = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='activation_alpha', default=None)
+    activation_beta  = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='activation_beta', default=None)
+    activations      = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='activations', default=None)
+    clip             = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='clip', default=None)
+    direction        = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='direction', default='forward')
+    hidden_size      = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='hidden_size', compulsive=True)
+    input_forget     = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='input_forget', default=0)
+    layout           = GET_ATTRIBUTE_FROM_OPERATION(op=op, attribute='layout', default=0)
+    if layout != 0: raise NotImplementedError('PPQ do not support LSTM with layout != 1.')
+    if activation_alpha is not None: raise NotImplementedError('PPQ do not support LSTM with cutimized activation.')
+    if activation_beta is not None: raise NotImplementedError('PPQ do not support LSTM with cutimized activation.')
+    if activations is not None: raise NotImplementedError('PPQ do not support LSTM with cutimized activation.')
+
+    # flag
+    bidirectional = (direction == 'bidirectional')
+    has_bias      = (b is not None)
+
+    if direction == 'reverse': raise NotImplementedError('GRU do not support reverse mode now.')
+
+    # create flatten weights:
+    if LSTM_FLATTEN_WEIGHT_ATTRIB not in op.attributes:
+        forward_w = torch.cat([
+            w[0][hidden_size * 0: hidden_size * 1],
+            w[0][hidden_size * 2: hidden_size * 3],
+            w[0][hidden_size * 3: hidden_size * 4],
+            w[0][hidden_size * 1: hidden_size * 2]], dim=0).contiguous()
+        forward_r = torch.cat([
+            r[0][hidden_size * 0: hidden_size * 1],
+            r[0][hidden_size * 2: hidden_size * 3],
+            r[0][hidden_size * 3: hidden_size * 4],
+            r[0][hidden_size * 1: hidden_size * 2]], dim=0).contiguous()
+        if has_bias:
+            forward_bias_1 = torch.cat([
+                b[0, hidden_size * 0: hidden_size * 1],
+                b[0, hidden_size * 2: hidden_size * 3],
+                b[0, hidden_size * 3: hidden_size * 4],
+                b[0, hidden_size * 1: hidden_size * 2]]).contiguous()
+            forward_bias_2 = torch.cat([
+                b[0, hidden_size * 4: hidden_size * 5],
+                b[0, hidden_size * 6: hidden_size * 7],
+                b[0, hidden_size * 7: hidden_size * 8],
+                b[0, hidden_size * 5: hidden_size * 6]]).contiguous()
+        if bidirectional == True:
+            reverse_w = torch.cat([
+                w[1][hidden_size * 0: hidden_size * 1],
+                w[1][hidden_size * 2: hidden_size * 3],
+                w[1][hidden_size * 3: hidden_size * 4],
+                w[1][hidden_size * 1: hidden_size * 2]], dim=0).contiguous()
+            reverse_r = torch.cat([
+                r[1][hidden_size * 0: hidden_size * 1],
+                r[1][hidden_size * 2: hidden_size * 3],
+                r[1][hidden_size * 3: hidden_size * 4],
+                r[1][hidden_size * 1: hidden_size * 2]], dim=0).contiguous()
+            if has_bias:
+                reverse_bias_1 = torch.cat([
+                    b[1, hidden_size * 0: hidden_size * 1],
+                    b[1, hidden_size * 2: hidden_size * 3],
+                    b[1, hidden_size * 3: hidden_size * 4],
+                    b[1, hidden_size * 1: hidden_size * 2]]).contiguous()
+                reverse_bias_2 = torch.cat([
+                    b[1, hidden_size * 4: hidden_size * 5],
+                    b[1, hidden_size * 6: hidden_size * 7],
+                    b[1, hidden_size * 7: hidden_size * 8],
+                    b[1, hidden_size * 5: hidden_size * 6]]).contiguous()
+        
+        flatten_weight = [forward_w, forward_r]
+        if has_bias:                   flatten_weight = [forward_w, forward_r, forward_bias_1, forward_bias_2]
+        if bidirectional:              flatten_weight = [forward_w, forward_r, reverse_w, reverse_r]
+        if bidirectional and has_bias: flatten_weight = [
+            forward_w, forward_r, forward_bias_1, forward_bias_2, reverse_w, reverse_r, reverse_bias_1, reverse_bias_2]
+        op.set_extension_attrib(LSTM_FLATTEN_WEIGHT_ATTRIB, flatten_weight)
+    # end if
+    
+    s = 2 if bidirectional else 1
+    if initial_h is None:
+        initial_h = torch.zeros(
+            size=[s, x.shape[1], x.shape[2]], 
+            device=x.device, dtype=torch.float32)
+
+    if initial_c is None:
+        initial_c = torch.zeros(
+            size=[s, x.shape[1], x.shape[2]], 
+            device=x.device, dtype=torch.float32)
+
+    result = _VF.lstm(
+        x,                                       # x
+        (initial_h, initial_c),                  # initial hidden state
+        op._detail[LSTM_FLATTEN_WEIGHT_ATTRIB],  # flatten weights
+        has_bias,                                # has bias
+        1,                                       # num of layer
+        0.0,                                     # dropout
+        False,                                   # training flag
+        bidirectional,                           # bidirectional
+        False)                                   # batch first
+
+    hs, h, c = result
+    if bidirectional:
+        hs = hs.reshape((hs.shape[0], hs.shape[1], 2, hs.shape[-1] // 2))
+        hs = hs.permute((0, 2, 1, 3))
+    else:
+        hs = hs.reshape((hs.shape[0], hs.shape[1], 1, hs.shape[-1]))
+        hs = hs.permute((0, 2, 1, 3))
+    return hs, h, c
 
 
 def Neg_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
@@ -2258,6 +2657,7 @@ def Identity_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBacken
     ASSERT_ALL_TENSORS_AT_SAME_DEVICE(op=op, values=values)
     ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
     return values[0]
+
 
 def Onehot_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     """Produces a one-hot tensor based on inputs. The locations represented by
@@ -2330,6 +2730,7 @@ def Onehot_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendC
         out = out.permute(order)
     return out
 
+
 def Reciprocal_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
     """
     Reciprocal takes one input data (Tensor) and produces one output data (Tensor) where the reciprocal is,
@@ -2360,7 +2761,64 @@ def LogSoftmax_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBack
     return x
 
 
+def Sin_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    """Calculates the sine of the given input tensor, element-wise.
+
+    Inputs
+        input (differentiable) : T
+            Input tensor
+    
+    Outputs
+        output (differentiable) : T
+            The sine of the input tensor computed element-wise
+    
+    Type Constraints
+    T : tensor(float16), tensor(float), tensor(double)
+    Constrain input and output types to float tensors.
+
+    Args:
+        op (Operation): _description_
+        values (List[torch.Tensor]): _description_
+        ctx (TorchBackendContext, optional): _description_. Defaults to None.
+
+    Returns:
+        torch.Tensor: _description_
+    """
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
+    [x] = values
+    return torch.sin(x)
+
+
+def Cos_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs) -> torch.Tensor:
+    """Calculates the cosine of the given input tensor, element-wise.
+
+    Inputs
+        input (differentiable) : T
+            Input tensor
+    
+    Outputs
+        output (differentiable) : T
+            The cosine of the input tensor computed element-wise
+    
+    Type Constraints
+    T : tensor(float16), tensor(float), tensor(double)
+    Constrain input and output types to float tensors.
+
+    Args:
+        op (Operation): _description_
+        values (List[torch.Tensor]): _description_
+        ctx (TorchBackendContext, optional): _description_. Defaults to None.
+
+    Returns:
+        torch.Tensor: _description_
+    """
+    ASSERT_NUM_OF_INPUT(op=op, values=values, min_num_of_input=1, max_num_of_input=1)
+    [x] = values
+    return torch.cos(x)
+
+
 DEFAULT_BACKEND_TABLE = {
+    'Abs': Abs_forward,
     'AdaptiveAvgPool2d': AdaptiveAvgPool2d_forward,
     'And':And_forward,
     'Add': Add_forward,
@@ -2374,6 +2832,7 @@ DEFAULT_BACKEND_TABLE = {
     'ConstantOfShape': ConstantOfShape_forward,
     'Conv': Conv_forward,
     'ConvTranspose': ConvTranspose_forward,
+    'Cos': Cos_forward,
     'Div': Eltwise_forward,
     'Equal': Equal_forward,
     'Exp': UnaryEltwise_forward,
@@ -2415,6 +2874,7 @@ DEFAULT_BACKEND_TABLE = {
     'ScatterND': ScatterND_forward,
     'Shape': Shape_forward,
     'Sigmoid': UnaryEltwise_forward,
+    'Sin': Sin_forward,
     'Slice': Slice_forward,
     'Softmax': Softmax_forward,
     'Softplus': Softplus_forward,
@@ -2450,5 +2910,5 @@ DEFAULT_BACKEND_TABLE = {
     'Identity': Identity_forward,
     'OneHot': Onehot_forward,
     'Reciprocal': Reciprocal_forward,
-
+    'LSTM': LSTM_forward,
 }

--- a/ppq/executor/op/torch/shape.py
+++ b/ppq/executor/op/torch/shape.py
@@ -1571,6 +1571,16 @@ def ReduceSum_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBacke
         output = torch.sum(input_value, dim=dim[0], keepdim=keepdim)
     return output
 
+
+def ScatterElements_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendContext = None, **kwargs):
+    input_data, indices, updates = values
+    dim = op.attributes.get('axis', 0)
+    # Negative indices
+    indices[indices < 0] += input_data.shape[dim]
+    output = input_data.scatter(dim, indices, updates)
+    return output
+
+
 SOI_BACKEND_TABLE = {
     'Shape': Shape_forward,
     'Div': Div_forward,
@@ -1616,4 +1626,5 @@ SOI_BACKEND_TABLE = {
     'GreaterOrEqual': GreaterOrEqual_forward,
     'LessOrEqual': LessOrEqual_forward,
     'ReduceSum': ReduceSum_forward,
+    'ScatterElements': ScatterElements_forward,
 }

--- a/ppq/executor/torch.py
+++ b/ppq/executor/torch.py
@@ -118,8 +118,8 @@ class TorchExecutor(BaseGraphExecutor, torch.nn.Module):
         super().__init__(graph)
         
         if not graph.extension_attrib.get(IS_DISPATCHED_GRAPH, False):
-            raise RuntimeError('Can initilize executor with your graph, cause it has not been correctly dispatched, '
-                               'use dispatch_graph(graph=ir, platform=platfrom, setting=setting) first.')
+            ppq_warning('Can initilize executor with your graph, cause it has not been correctly dispatched, '
+                        'use dispatch_graph(graph=ir, platform=platfrom, setting=setting) first.')
         
         self._runnable_graph = RunnableGraph(self._graph)
         self._delegates = {}

--- a/ppq/executor/torch.py
+++ b/ppq/executor/torch.py
@@ -1,9 +1,9 @@
 from typing import Any, Callable, Dict, List, Union
 
 import numpy
-from ppq.core import (DataType, OperationMeta, QuantizationStates,
-                      TargetPlatform, TensorMeta, TensorQuantizationConfig,
-                      empty_ppq_cache, ppq_warning)
+from ppq.core import (IS_DISPATCHED_GRAPH, DataType, OperationMeta,
+                      QuantizationStates, TargetPlatform, TensorMeta,
+                      TensorQuantizationConfig, empty_ppq_cache, ppq_warning)
 from ppq.IR import BaseGraph, Operation, QuantableOperation, RunnableGraph
 from ppq.IR.base.command import GraphDeployCommand
 from ppq.quantization.qfunction.linear import PPQLinearQuantFunction
@@ -116,6 +116,11 @@ class TorchExecutor(BaseGraphExecutor, torch.nn.Module):
         self._device = device
         self._executing_context = TorchBackendContext(executing_device=self._device)
         super().__init__(graph)
+        
+        if not graph.extension_attrib.get(IS_DISPATCHED_GRAPH, False):
+            raise RuntimeError('Can initilize executor with your graph, cause it has not been correctly dispatched, '
+                               'use dispatch_graph(graph=ir, platform=platfrom, setting=setting) first.')
+        
         self._runnable_graph = RunnableGraph(self._graph)
         self._delegates = {}
 

--- a/ppq/parser/matex_exporter.py
+++ b/ppq/parser/matex_exporter.py
@@ -13,6 +13,7 @@ from ppq.IR import (BaseGraph, Operation, QuantableOperation,
                     QuantableVariable, Variable)
 from ppq.IR.base.command import GraphCommand, GraphCommandType
 from ppq.IR.morph import GraphDeviceSwitcher, GraphFormatter
+from ppq.core.common import GRAPH_OPSET_ATTRIB
 from ppq.utils.round import ppq_tensor_round
 
 from .onnx_exporter import OnnxExporter
@@ -346,8 +347,8 @@ class MetaxExporter(OnnxExporter):
         extra_opsets = self.required_opsets()
 
         opsets = []
-        if 'opsets' in graph._detail:
-            for opset in graph._detail['opsets']:
+        if GRAPH_OPSET_ATTRIB in graph._detail:
+            for opset in graph._detail[GRAPH_OPSET_ATTRIB]:
                 if opset['domain'] in extra_opsets or opset['domain'] == '':
                     continue
                 op = onnx.OperatorSetIdProto()

--- a/ppq/parser/onnx_exporter.py
+++ b/ppq/parser/onnx_exporter.py
@@ -5,9 +5,8 @@ import numpy as np
 import onnx
 import torch
 from onnx import helper, numpy_helper
-from ppq.core import (ONNX_EXPORT_OPSET, ONNX_VERSION, PPQ_CONFIG, DataType,
-                      convert_any_to_numpy)
-from ppq.core.defs import ppq_warning
+from ppq.core import (GRAPH_OPSET_ATTRIB, ONNX_EXPORT_OPSET, ONNX_VERSION,
+                      PPQ_CONFIG, DataType, convert_any_to_numpy, ppq_warning)
 from ppq.IR import (BaseGraph, GraphExporter, Operation, OperationExporter,
                     Variable)
 from ppq.IR.morph import GraphDeviceSwitcher
@@ -205,13 +204,13 @@ class OnnxExporter(GraphExporter):
         )
 
         # force opset to 11
-        if 'opsets' not in graph._detail:
+        if GRAPH_OPSET_ATTRIB not in graph._detail:
             op = onnx.OperatorSetIdProto()
             op.version = ONNX_EXPORT_OPSET
             opsets = [op]
         else:
             opsets = []
-            for opset in graph._detail['opsets']:
+            for opset in graph._detail[GRAPH_OPSET_ATTRIB]:
                 op = onnx.OperatorSetIdProto()
                 op.domain = opset['domain']
                 op.version = opset['version']

--- a/ppq/parser/onnx_parser.py
+++ b/ppq/parser/onnx_parser.py
@@ -1,12 +1,11 @@
 from typing import Any, Dict, Iterable, List
 
-from torch import random
-
-from ppq.core import NetworkFramework, is_file_exist, DEFAULT_OPSET_DOMAIN, DEFAULT_OPSET_VERSION
-from ppq.IR import BaseGraph, GraphBuilder, Operation, Variable, Opset
-
 import onnx
 from onnx import helper, mapping, numpy_helper
+from ppq.core import (DEFAULT_OPSET_DOMAIN, DEFAULT_OPSET_VERSION,
+                      GRAPH_OPSET_ATTRIB, NetworkFramework, is_file_exist)
+from ppq.IR import BaseGraph, GraphBuilder, Operation, Opset, Variable
+from torch import random
 
 
 class OnnxParser(GraphBuilder):
@@ -96,11 +95,11 @@ class OnnxParser(GraphBuilder):
             f'onnx load failed, only ProtoBuffer object is expected here, while {type(model_pb)} is loaded.'
         graph_pb = model_pb.graph
         graph = BaseGraph(name=graph_pb.name, built_from=NetworkFramework.ONNX)
-        graph._detail['opsets'] = self.convert_opsets_to_str(opsets)
+        graph._detail[GRAPH_OPSET_ATTRIB] = self.convert_opsets_to_str(opsets)
         graph._detail['ir_version'] = model_pb.ir_version
 
         onnx_import_opset = DEFAULT_OPSET_VERSION
-        for opset in graph._detail['opsets']:
+        for opset in graph._detail[GRAPH_OPSET_ATTRIB]:
             if opset['domain'] == DEFAULT_OPSET_DOMAIN or opset['domain'] == '':
                 onnx_import_opset = opset['version']
                 break

--- a/ppq/parser/tensorRT.py
+++ b/ppq/parser/tensorRT.py
@@ -35,7 +35,21 @@ from .onnxruntime_exporter import ONNXRUNTIMExporter
 
 
 class TensorRTExporter(ONNXRUNTIMExporter):
-
+    """
+    TensorRT PPQ 0.6.4 以来新加入的功能
+    
+    你需要注意，只有 TensorRT 8.0 以上的版本支持读取 PPQ 导出的量化模型
+    并且 TensorRT 对于量化模型的解析存在一些 Bug，
+    
+    如果你遇到模型解析不对的问题，欢迎随时联系我们进行解决。
+    
+        已知的问题包括：
+        1. 模型导出时最好不要包含其他 opset，如果模型上面带了别的opset，比如 mmdeploy，trt有可能会解析失败
+        2. 模型导出时可能出现 Internal Error 10, Invalid Node xxx()，我们还不知道如何解决该问题
+    
+    Args:
+        ONNXRUNTIMExporter (_type_): _description_
+    """
     def insert_quant_dequant_on_variable(
         self, graph: BaseGraph, var: QuantableVariable, op: QuantableOperation,
         config: TensorQuantizationConfig) -> None:
@@ -191,7 +205,7 @@ class TensorRTExporter(ONNXRUNTIMExporter):
                     return None
 
             config = builder.create_builder_config()
-            config.max_workspace_size = 2 << 30
+            config.max_workspace_size = 8 << 30
             config.flags = config.flags | 1 << int(trt.BuilderFlag.INT8)
 
             profile = builder.create_optimization_profile()

--- a/ppq/parser/util.py
+++ b/ppq/parser/util.py
@@ -24,7 +24,7 @@ def convert_value(
     value = convert_any_to_numpy(value, accepet_none=False)
     value = value.astype(dtype=DataType.to_numpy(dtype))
     if export_as_float:
-        value = np.asscalar(value[0])
+        value = value[0].item()
         assert type(value) in {int, float}, (
             f'Trying to dump a tensorwise quantization value {value}. '
             f'It is Expected to be a int or float value, while {type(value)} was given')

--- a/ppq/quantization/analyse/__init__.py
+++ b/ppq/quantization/analyse/__init__.py
@@ -1,2 +1,3 @@
-from .layerwise import layerwise_error_analyse
-from .graphwise import graphwise_error_analyse
+from .graphwise import graphwise_error_analyse, statistical_analyse
+from .layerwise import (layerwise_error_analyse, parameter_analyse,
+                        variable_analyse)

--- a/ppq/quantization/analyse/graphwise.py
+++ b/ppq/quantization/analyse/graphwise.py
@@ -1,13 +1,12 @@
 
-from typing import Callable, Dict, Iterator
+from typing import Callable, Dict, Iterator, List
 
 import torch
-from ppq.core import OperationMeta
-from ppq.core.quant import QuantizationStates
+from ppq.core import PASSIVE_OPERATIONS, OperationMeta
 from ppq.executor import RuntimeHook, TorchExecutor
-from ppq.IR import BaseGraph, Operation
-from ppq.IR.quantize import QuantableOperation
-from ppq.utils.fetch import batch_random_fetch
+from ppq.IR import BaseGraph, Operation, QuantableOperation, Variable
+from ppq.quantization.measure.norm import torch_snr_error
+from ppq.utils.fetch import batch_random_fetch, tensor_random_fetch
 from tqdm import tqdm
 
 from .util import MeasurePrinter, MeasureRecorder
@@ -38,6 +37,32 @@ class OutputRecorder(RuntimeHook):
         fetched = self.fetched
         self.fetched = None
         return fetched
+
+
+class DetailedRecorder(RuntimeHook):
+    def __init__(self, operation: Operation,
+        operation_meta: OperationMeta = None, 
+        fetchs: int = 1024) -> None:
+        self.fetchs      = fetchs
+        self.i_storage   = [[] for _ in range(operation.num_of_input)]
+        self.o_storage   = [[] for _ in range(operation.num_of_output)]
+        super().__init__(operation, operation_meta=operation_meta)
+
+    def pre_forward_hook(self, inputs: List[torch.Tensor], **kwargs) -> list:
+        for idx, input in enumerate(inputs):
+            self.i_storage[idx].append(tensor_random_fetch(
+            input, seed=10086, num_of_fetches=self.fetchs).to('cpu'))
+        return super().pre_forward_hook(inputs, **kwargs)
+
+    def post_forward_hook(self, outputs: List[torch.Tensor], **kwargs) -> list:
+        for idx, output in enumerate(outputs):
+            self.o_storage[idx].append(tensor_random_fetch(
+            output, seed=10086, num_of_fetches=self.fetchs).to('cpu'))
+        return super().post_forward_hook(outputs, **kwargs)
+
+    def clear(self):
+        self.i_storage = [[] for _ in range(self._hook_to.num_of_input)]
+        self.o_storage = [[] for _ in range(self._hook_to.num_of_output)]
 
 
 def graphwise_error_analyse(
@@ -156,3 +181,192 @@ def graphwise_error_analyse(
         if method == 'mse': method_str = 'MSE LOSS(UNSCALED)'
         MeasurePrinter(results, order='large_to_small', measure=method_str).print()
     return results
+
+
+def statistical_analyse(
+    graph: BaseGraph, running_device: str,
+    dataloader: Iterator, collate_fn: Callable = None,
+    steps: int = 8, ) -> List[dict]:
+    """ It is time to do some statistical work.
+
+    statistical_analyse is a powerful analying function
+        that provides a in-depth study of your network.
+
+    use report = statistical_analyse() to invoke this function
+    
+    The return value of this function is a collection of statistics parameters
+    You are recommended to processing them with pandas
+    
+    from pandas import Dataframe
+    report_df = Dataframe(report)
+
+    Args:
+        graph (BaseGraph): _description_
+        running_device (str): _description_
+        dataloader (Iterator): _description_
+        collate_fn (Callable, optional): _description_. Defaults to None.
+        steps (int, optional): _description_. Defaults to 8.
+
+    Returns:
+        Dict[str, float]: _description_
+    """
+
+    class StatisticalErrorAnalyser:
+        def __init__(self, x_fp: List[torch.Tensor], x_qt: List[torch.Tensor], 
+                     op: Operation, var: Variable) -> None:
+            self.x_qt = torch.cat(x_qt, dim=0)
+            self.x_fp = torch.cat(x_fp, dim=0)
+            self.x_er = self.x_qt - self.x_fp
+            self.op   = op
+            self.var  = var
+
+            self.num_of_samples = self.x_fp.shape[0]
+
+        def stat(self) -> dict:
+            x_er, x_fp, x_qt = self.x_er, self.x_fp, self.x_qt
+            er_mean     = x_er.mean().item()
+            er_std      = x_er.std().item()
+            er_min      = x_er.min().item()
+            er_max      = x_er.max().item()
+            er_skew     = self.solve_skewness(x_er, er_mean, er_std).item()
+            er_kurtosis = self.solve_kurtosis(x_er, er_mean, er_std).item()
+            er_hist     = torch.histc(x_er, bins=32, min=x_er.min(), max=x_er.max()).cpu().tolist()
+
+            qt_mean     = x_qt.mean().item()
+            qt_std      = x_qt.std().item()
+            qt_min      = x_qt.min().item()
+            qt_max      = x_qt.max().item()
+            qt_skew     = self.solve_skewness(x_qt, qt_mean, qt_std).item()
+            qt_kurtosis = self.solve_kurtosis(x_qt, qt_mean, qt_std).item()
+            qt_hist     = torch.histc(x_qt, bins=32, min=x_qt.min(), max=x_qt.max()).cpu().tolist()
+
+            fp_mean     = x_fp.mean().item()
+            fp_std      = x_fp.std().item()
+            fp_min      = x_fp.min().item()
+            fp_max      = x_fp.max().item()
+            fp_skew     = self.solve_skewness(x_fp, fp_mean, fp_std).item()
+            fp_kurtosis = self.solve_kurtosis(x_fp, fp_mean, fp_std).item()
+            fp_hist     = torch.histc(x_fp, bins=32, min=x_fp.min(), max=x_fp.max()).cpu().tolist()
+
+            snr         = torch_snr_error(x_qt, x_fp).item()
+            return {
+                'Op name': self.op.name,
+                'Op type': self.op.type,
+                'Is parameter': self.var.is_parameter,
+                'Is input': self.var in self.op.inputs,
+                'Is output': self.var in self.op.outputs,
+
+                'Variable name': self.var.name,
+                'Noise:Signal Power Ratio': snr,
+
+                'Noise Mean'    : er_mean,
+                'Noise Std'     : er_std,
+                'Noise Skewness': er_skew,
+                'Noise Kurtosis': er_kurtosis,
+                'Noise Hist'    : er_hist,
+                'Noise Max'     : er_max,
+                'Noise Min'     : er_min,
+
+                'Quantized Mean'    : qt_mean,
+                'Quantized Std'     : qt_std,
+                'Quantized Skewness': qt_skew,
+                'Quantized Kurtosis': qt_kurtosis,
+                'Quantized Hist'    : qt_hist,
+                'Quantized Max'     : qt_max,
+                'Quantized Min'     : qt_min,
+
+                'Float Mean'    : fp_mean,
+                'Float Std'     : fp_std,
+                'Float Skewness': fp_skew,
+                'Float Kurtosis': fp_kurtosis,
+                'Float Hist'    : fp_hist,
+                'Float Max'     : fp_max,
+                'Float Min'     : fp_min
+            }
+
+        def solve_skewness(self, x:torch.Tensor, mean: float, std: float) -> torch.Tensor:
+            # 三次方可能有数据溢出
+            return torch.pow((x - mean) / std, 3).mean()
+
+        def solve_kurtosis(self, x:torch.Tensor, mean: float, std: float) -> torch.Tensor:
+            # 四次方可能有数据溢出
+            return torch.pow((x - mean) / std, 4).mean() - 3
+
+    executor = TorchExecutor(graph=graph, device=running_device)
+    # find all quantable operations.
+    interested_op = []
+    for operation in graph.operations.values():
+        if isinstance(operation, QuantableOperation) and operation.type not in PASSIVE_OPERATIONS:
+            interested_op.append(operation)
+    if len(interested_op) == 0:
+        print('Oops. you got nothing to analyse.')
+        return
+
+    # set up all hooks.
+    hooks, caches = {}, {}
+    for operation in interested_op:
+        if isinstance(operation, QuantableOperation):
+            hooks[operation.name] = DetailedRecorder(
+                operation=operation, operation_meta=operation.meta_data)
+            caches[operation.name] = {
+                'Quantized Input': [], 'Quantized Output': [], 
+                'Dequantized Input': [], 'Dequantized Output': []}
+
+    # dequantize all
+    for operation in graph.operations.values():
+        if isinstance(operation, QuantableOperation):
+            operation.dequantize()
+
+    # run for each quantable operations:
+    for idx, batch in tqdm(enumerate(dataloader),
+                           desc='Analysing Phrase 1',
+                           total=(min(len(dataloader), steps))):
+        if collate_fn is not None: batch = collate_fn(batch)
+        executor.forward(inputs=batch, hooks=hooks)
+        if idx >= steps: break
+    
+    for operation in interested_op:
+        hook = hooks[operation.name]
+        assert isinstance(hook, DetailedRecorder)
+        caches[operation.name]['Dequantized Input'] = hook.i_storage.copy()
+        caches[operation.name]['Dequantized Output'] = hook.o_storage.copy()
+        hook.clear()
+
+    # restore all
+    for operation in graph.operations.values():
+        if isinstance(operation, QuantableOperation):
+            operation.restore_quantize_state()
+
+    # run for each quantable operations:
+    for idx, batch in tqdm(enumerate(dataloader),
+                           desc='Analysing Phrase 2',
+                           total=(min(len(dataloader), steps))):
+        if collate_fn is not None: batch = collate_fn(batch)
+        executor.forward(inputs=batch, hooks=hooks)
+        if idx >= steps: break
+
+    for operation in interested_op:
+        hook = hooks[operation.name]
+        assert isinstance(hook, DetailedRecorder)
+        caches[operation.name]['Quantized Input'] = hook.i_storage.copy()
+        caches[operation.name]['Quantized Output'] = hook.o_storage.copy()
+        hook.clear()
+
+    # analysing cache
+    records = []
+    for name, record in caches.items():
+        operation = graph.operations[name]
+        assert isinstance(operation, Operation)
+        for idx, input_var in enumerate(operation.inputs):
+            x_qt = record['Quantized Input'][idx]
+            x_fp = record['Dequantized Input'][idx]
+            records.append(StatisticalErrorAnalyser(
+                x_fp = x_fp, x_qt = x_qt, op=operation, var=input_var).stat())
+
+        for idx, output_var in enumerate(operation.outputs):
+            x_qt = record['Quantized Output'][idx]
+            x_fp = record['Dequantized Output'][idx]
+            records.append(StatisticalErrorAnalyser(
+                x_fp = x_fp, x_qt = x_qt, op=operation, var=output_var).stat())
+
+    return records

--- a/ppq/quantization/observer/__init__.py
+++ b/ppq/quantization/observer/__init__.py
@@ -7,6 +7,7 @@ from ppq.executor import QuantOPRuntimeHook
 from ppq.IR import QuantableOperation, Variable
 
 from .base import BaseTensorObserver
+from .order import TorchIsotoneObserver
 from .range import (TorchHistObserver, TorchMinMaxObserver, TorchMSEObserver,
                     TorchPercentileObserver)
 
@@ -14,7 +15,8 @@ PPQ_OBSERVER_TABLE = {
     'minmax': TorchMinMaxObserver,
     'kl': TorchHistObserver,
     'percentile': TorchPercentileObserver,
-    'mse': TorchMSEObserver
+    'mse': TorchMSEObserver,
+    'isotone': TorchIsotoneObserver
 }
 
 

--- a/ppq/quantization/observer/order.py
+++ b/ppq/quantization/observer/order.py
@@ -1,13 +1,21 @@
-from .base import BaseTensorObserver
 import torch
+from ppq.core import (CUDA, PPQ_CONFIG, QuantizationProperty,
+                      QuantizationStates, TensorQuantizationConfig,
+                      ppq_warning)
+from ppq.IR.base.graph import Variable
+
+from .base import BaseTensorObserver
 
 
-class OrderPreservingObserver(BaseTensorObserver):
+class TorchIsotoneObserver(BaseTensorObserver):
+    def __init__(self, watch_on: Variable, quant_cfg: TensorQuantizationConfig):
+        super().__init__(watch_on, quant_cfg)
+        self._cache = []
     """For softmax or sigmoid activations, usually we just need
     argmax(softmax(x)) == argmax(softmax(quant(x))) which is argmax(x) ==
     argmax(quant(x))
 
-    Inspired by this Property, we designed a order preserving calibration method,
+    Inspired by this Property, we designed an order-preserving calibration method,
         which cares only about max(x) [or min(x)]
 
     To keep argmax(x) == argmax(quant(x)), we only need to
@@ -22,12 +30,51 @@ class OrderPreservingObserver(BaseTensorObserver):
             clip(round(L1 / scale)) > clip(round(L2 / scale))
         Which means:
             1. L1 - L2 > 0.5 * scale
-            2. round(L2 / scale) < clip_max
+            2. round(L2 / scale) < clip_max - 1
     Args:
         BaseTensorObserver ([type]): [description]
     """
     def observe(self, value: torch.Tensor):
-        return super().observe(value)
+        assert isinstance(value, torch.Tensor), 'IsotoneObserver can only deal with torch Tensor values'
+        assert value.numel() > 0, (f'You are observing an empty tensor({self._watch_on.name}).')
+        if self._quant_cfg.state == QuantizationStates.INITIAL:
+            if self._quant_cfg.policy.has_property(QuantizationProperty.PER_TENSOR):
+                # flatten value as [batch, num_of_elements]
+                value = value.flatten(start_dim=1)
+                value, _ = torch.topk(value, k=2, dim=-1, largest=True, sorted=True)
+                self._cache.append(value)
+            elif self._quant_cfg.policy.has_property(QuantizationProperty.PER_CHANNEL):
+                raise TypeError('IsotoneObserver is not designed for channelwise quantization.')
+            else:
+                raise TypeError('Min-max Observer only work with per-tensor or per-channel quantize policy.')
+
 
     def render_quantization_config(self):
-        return super().render_quantization_config()
+        device = self._cache[-1].device
+        collected = torch.cat(self._cache, dim=0)
+        collected = collected.cpu().numpy()
+        s_maxs, s_mins = [], []
+        for l1, l2 in collected:
+            scale_min = l2 / (self._quant_cfg.quant_max - 1)
+            scale_max = 2 * (l1 - l2)
+            s_maxs.append(scale_max)
+            s_mins.append(scale_min)
+
+        best_satisfied, best_scales = 0, []
+        for s_candidate in s_maxs + s_mins:
+            satisfied = 0
+
+            for s_max, s_min in zip(s_maxs, s_mins):
+                if s_candidate <= s_max: satisfied += 1
+                if s_candidate >= s_min: satisfied += 1
+
+            if satisfied > best_satisfied:
+                best_satisfied = satisfied
+                best_scales    = [s_candidate]
+            if satisfied == best_satisfied:
+                best_scales.append(s_candidate)
+
+        best_scale = sum(best_scales) / len(best_scales)
+        self._quant_cfg.scale  = torch.tensor([best_scale], dtype=torch.float32, device=device).squeeze(0)
+        self._quant_cfg.offset = torch.tensor([0], dtype=torch.float32, device=device).squeeze(0)
+        self._quant_cfg.state = QuantizationStates.ACTIVATED

--- a/ppq/quantization/optim/refine.py
+++ b/ppq/quantization/optim/refine.py
@@ -4,8 +4,8 @@ from typing import Iterable, List, Set
 import torch
 from ppq.core import (COMPELING_OP_TYPES, PPLCUDA_ACTIVATIONS,
                       QuantizationProperty, QuantizationStates, RoundingPolicy,
-                      TensorQuantizationConfig, empty_ppq_cache)
-from ppq.core.defs import ppq_warning
+                      TargetPlatform, TensorQuantizationConfig,
+                      empty_ppq_cache, ppq_warning)
 from ppq.executor import BaseGraphExecutor
 from ppq.IR import GraphCommandProcessor, QuantableOperation, Variable
 from ppq.IR.base.graph import Operation
@@ -344,7 +344,11 @@ class QuantizeFusionPass(QuantizationOptimizationPass):
 
             for pattern in patterns:
                 computing_op, act_op = pattern
-                if not isinstance(computing_op, QuantableOperation): 
+                
+                if (not isinstance(computing_op, QuantableOperation) or 
+                    computing_op.platform in {
+                        TargetPlatform.TRT_INT8, TargetPlatform.OPENVINO_INT8, 
+                        TargetPlatform.NCNN_INT8}): 
                     continue
 
                 if (computing_op.platform != act_op.platform and 

--- a/ppq/quantization/quantizer/PPLQuantizer.py
+++ b/ppq/quantization/quantizer/PPLQuantizer.py
@@ -26,8 +26,7 @@ class PPLCUDAQuantizer(BaseQuantizer):
             policy=self.quantize_policy, rounding=self.rounding_policy,
             operation_meta=operation.meta_data, num_of_bits=self._num_of_bits,
             quant_max=self._quant_max, quant_min=self._quant_min,
-            observer_algorithm='percentile'
-        )
+            observer_algorithm='percentile')
 
         if operation.type in {'Conv', 'ConvTranspose', 'Gemm'}:
             # set all parameters within Conv, ConvTranspose, Gemm to per-channel quant-config.

--- a/ppq/samples/TensorRT/Benchmark_with_onnx.py
+++ b/ppq/samples/TensorRT/Benchmark_with_onnx.py
@@ -1,0 +1,120 @@
+# ---------------------------------------------------------------
+# 这个脚本向你展示了如何使用 tensorRT 对 PPQ 导出的模型进行推理，并进行速度测试
+# 目前 GPU 上 tensorRT 是跑的最快的部署框架 ...
+# ---------------------------------------------------------------
+
+import time
+
+import numpy as np
+import tensorrt as trt
+import torch
+import torchvision
+import torchvision.models
+from tqdm import tqdm
+
+import trt_infer
+from ppq import *
+from ppq.api import *
+
+# Nvidia Nsight Performance Profile
+QUANT_PLATFROM   = TargetPlatform.TRT_INT8
+BATCHSIZE        = 1
+SAMPLES          = [torch.zeros(size=[BATCHSIZE, 3, 640, 640]) for _ in range(32)]
+DEVICE           = 'cuda'
+MODEL_PATH       = 'models/yolov6s.onnx'
+CFG_VALID_RESULT = False
+
+def infer_trt(model_path: str, samples: List[np.ndarray]) -> List[np.ndarray]:
+    """ Run a tensorrt model with given samples
+    """
+    logger = trt.Logger(trt.Logger.ERROR)
+    with open(model_path, 'rb') as f, trt.Runtime(logger) as runtime:
+        engine = runtime.deserialize_cuda_engine(f.read())
+
+    results = []
+    if CFG_VALID_RESULT:
+        with engine.create_execution_context() as context:
+            inputs, outputs, bindings, stream = trt_infer.allocate_buffers(context.engine)
+            for sample in tqdm(samples, desc='TensorRT is running...'):
+                inputs[0].host = convert_any_to_numpy(sample)
+                [output] = trt_infer.do_inference(
+                    context, bindings=bindings, inputs=inputs, 
+                    outputs=outputs, stream=stream, batch_size=1)[0]
+                results.append(convert_any_to_torch_tensor(output).reshape([-1, 1000]))
+    else:
+        with engine.create_execution_context() as context:
+            inputs, outputs, bindings, stream = trt_infer.allocate_buffers(context.engine)
+            inputs[0].host = convert_any_to_numpy(samples[0])
+            for sample in tqdm(samples, desc='TensorRT is running...'):
+                trt_infer.do_inference(
+                    context, bindings=bindings, inputs=inputs, 
+                    outputs=outputs, stream=stream, batch_size=1)
+    return results
+
+
+with ENABLE_CUDA_KERNEL():
+    # export non-quantized model to tensorRT for benchmark
+    non_quantized = quantize_onnx_model(
+        onnx_import_file=MODEL_PATH, calib_dataloader=SAMPLES, 
+        collate_fn=lambda x: x.to(DEVICE),
+        calib_steps=32, input_shape=[BATCHSIZE, 3, 640, 640],
+        setting=QuantizationSettingFactory.default_setting(),
+        platform=QUANT_PLATFROM,
+        do_quantize=False)
+
+    export_ppq_graph(
+        graph=non_quantized, 
+        platform=TargetPlatform.ONNX,
+        graph_save_to='model_fp32.onnx')
+    builder = trt_infer.EngineBuilder()
+    builder.create_network('model_fp32.onnx')
+    builder.create_engine(engine_path='model_fp32.engine', precision="fp16")
+
+    # quantize model with ppq.
+    quantized = quantize_onnx_model(
+        onnx_import_file=MODEL_PATH, calib_dataloader=SAMPLES, 
+        collate_fn=lambda x: x.to(DEVICE),
+        calib_steps=32, input_shape=[BATCHSIZE, 3, 640, 640],
+        setting=QuantizationSettingFactory.default_setting(),
+        platform=QUANT_PLATFROM)
+
+    if CFG_VALID_RESULT:
+        executor = TorchExecutor(graph=quantized)
+        ref_results = []
+        for sample in tqdm(SAMPLES, desc='PPQ GENERATEING REFERENCES', total=len(SAMPLES)):
+            result = executor.forward(inputs=sample.to(DEVICE))[0]
+            result = result.cpu().reshape([-1, 1000])
+            ref_results.append(result)
+
+    # export model to disk.
+    export_ppq_graph(
+        graph=quantized, 
+        platform=TargetPlatform.TRT_INT8,
+        graph_save_to='model_int8.onnx')
+    
+    if CFG_VALID_RESULT:
+        # compute simulating error
+        trt_outputs = infer_trt(
+            model_path='model_int8.engine', 
+            samples=[convert_any_to_numpy(sample) for sample in SAMPLES])
+
+        error = []
+        for ref, real in zip(ref_results, trt_outputs):
+            ref = convert_any_to_torch_tensor(ref).float()
+            real = convert_any_to_torch_tensor(real).float()
+            error.append(torch_snr_error(ref, real))
+        error = sum(error) / len(error) * 100
+        print(f'Simulating Error: {error: .4f}%')
+
+    # benchmark with onnxruntime int8
+    benchmark_samples = [np.zeros(shape=[BATCHSIZE, 3, 224, 224], dtype=np.float32) for _ in range(512)]
+    print(f'Start Benchmark with tensorRT (Batchsize = {BATCHSIZE})')
+    tick = time.time()
+    infer_trt(model_path='model_fp32.engine', samples=benchmark_samples)
+    tok  = time.time()
+    print(f'Time span (FP32 MODE): {tok - tick : .4f} sec')
+
+    tick = time.time()
+    infer_trt(model_path='model_int8.engine', samples=benchmark_samples)
+    tok  = time.time()
+    print(f'Time span (INT8 MODE): {tok - tick  : .4f} sec')

--- a/ppq/samples/TensorRT/Example_Benchmark.py
+++ b/ppq/samples/TensorRT/Example_Benchmark.py
@@ -31,6 +31,8 @@ DEVICE  = 'cuda'
 
 def infer_trt(model_path: str, samples: List[np.ndarray]) -> List[np.ndarray]:
     """ Run a tensorrt model with given samples
+    你需要注意我这里留了数据 IO，数据总是从 host 送往 device 的
+    如果你只关心 GPU 上的运行时间，你应该修改这个方法使得数据不发生迁移
     """
     logger = trt.Logger(trt.Logger.INFO)
     with open(model_path, 'rb') as f, trt.Runtime(logger) as runtime:
@@ -46,6 +48,7 @@ def infer_trt(model_path: str, samples: List[np.ndarray]) -> List[np.ndarray]:
                 outputs=outputs, stream=stream, batch_size=1)
             results.append(convert_any_to_torch_tensor(output).reshape([-1, 1000]))
     return results
+
 
 for mname, model_builder in MODELS.items():
     print(f'Ready for run quantization with {mname}')

--- a/ppq/samples/TensorRT/Example_Profiling.py
+++ b/ppq/samples/TensorRT/Example_Profiling.py
@@ -1,0 +1,54 @@
+# ---------------------------------------------------------------
+# 这个脚本向你展示了如何使用 tensorRT 对 PPQ 导出的模型进行推理，并进行速度测试
+# 目前 GPU 上 tensorRT 是跑的最快的部署框架 ...
+# ---------------------------------------------------------------
+
+import time
+import numpy as np
+import tensorrt as trt
+import torch
+import torchvision
+import torchvision.models
+from tqdm import tqdm
+
+import trt_infer
+from ppq import *
+from ppq.api import *
+
+# Nvidia Nsight Performance Profile
+QUANT_PLATFROM   = TargetPlatform.TRT_INT8
+BATCHSIZE        = 1
+SAMPLES          = [torch.zeros(size=[BATCHSIZE, 3, 640, 640]) for _ in range(32)]
+DEVICE           = 'cuda'
+MODEL_PATH       = 'model_int8.engine'
+CFG_VALID_RESULT = False
+
+def infer_trt(model_path: str, samples: List[np.ndarray]) -> List[np.ndarray]:
+    """ Run a tensorrt model with given samples
+    """
+    logger = trt.Logger(trt.Logger.ERROR)
+    with open(model_path, 'rb') as f, trt.Runtime(logger) as runtime:
+        engine = runtime.deserialize_cuda_engine(f.read())
+
+    results = []
+    if CFG_VALID_RESULT:
+        with engine.create_execution_context() as context:
+            inputs, outputs, bindings, stream = trt_infer.allocate_buffers(context.engine)
+            for sample in tqdm(samples, desc='TensorRT is running...'):
+                inputs[0].host = convert_any_to_numpy(sample)
+                [output] = trt_infer.do_inference(
+                    context, bindings=bindings, inputs=inputs, 
+                    outputs=outputs, stream=stream, batch_size=1)[0]
+                results.append(convert_any_to_torch_tensor(output).reshape([-1, 1000]))
+    else:
+        with engine.create_execution_context() as context:
+            context.profiler = trt.Profiler()
+            inputs, outputs, bindings, stream = trt_infer.allocate_buffers(context.engine)
+            inputs[0].host = convert_any_to_numpy(samples[0])
+            for sample in tqdm(samples, desc='TensorRT is running...'):
+                trt_infer.do_inference(
+                    context, bindings=bindings, inputs=inputs, 
+                    outputs=outputs, stream=stream, batch_size=1)
+    return results
+
+infer_trt(model_path=MODEL_PATH, samples=SAMPLES)

--- a/ppq/samples/analyse.py
+++ b/ppq/samples/analyse.py
@@ -8,9 +8,10 @@ import torchvision
 from ppq import (QuantizationSettingFactory, TargetPlatform,
                  graphwise_error_analyse)
 from ppq.api import quantize_torch_model
+from ppq.quantization.analyse.graphwise import statistical_analyse
+from ppq.quantization.analyse.layerwise import (layerwise_error_analyse,
+                                                parameter_analyse)
 from torch.utils.data import DataLoader
-
-from ppq.quantization.analyse.layerwise import layerwise_error_analyse, parameter_analyse
 
 BATCHSIZE = 32
 INPUT_SHAPE = [3, 224, 224]
@@ -59,3 +60,13 @@ reports = layerwise_error_analyse(
 
 # WITH PPQ 0.6 or newer, you can invoke parameter_analyse to get a more detailed report.
 parameter_analyse(graph=quantized)
+
+# WITH PPQ 0.6.5 or higher version
+report = statistical_analyse(
+    graph=quantized, running_device=DEVICE, 
+    collate_fn=collate_fn, dataloader=calibration_dataloader)
+
+from pandas import DataFrame
+
+report = DataFrame(report)
+report.to_csv('1.csv')

--- a/ppq/samples/dispatch.py
+++ b/ppq/samples/dispatch.py
@@ -1,17 +1,17 @@
+import random
 from typing import Iterable
 
-import random
 import torch
 import torchvision
+from ppq import BaseGraph, QuantizationSettingFactory, TargetPlatform
+from ppq.api import (QuantizationSettingFactory, dump_torch_to_onnx,
+                     export_ppq_graph, load_graph, quantize_torch_model)
 from torch.utils.data import DataLoader
 
-from ppq import BaseGraph, QuantizationSettingFactory, TargetPlatform
-from ppq.api import export_ppq_graph, quantize_torch_model, QuantizationSettingFactory, load_graph, dump_torch_to_onnx
-
-BATCHSIZE = 32
+BATCHSIZE   = 32
 INPUT_SHAPE = [3, 224, 224]
-DEVICE = 'cuda' # only cuda is fully tested :(  For other executing device there might be bugs.
-PLATFORM = TargetPlatform.PPL_CUDA_INT8  # identify a target platform for your network.
+DEVICE      = 'cuda'
+PLATFORM    = TargetPlatform.PPL_CUDA_INT8  # identify a target platform for your network.
 
 def load_calibration_dataset() -> Iterable:
     return [torch.rand(size=INPUT_SHAPE) for _ in range(32)]
@@ -32,8 +32,6 @@ dump_torch_to_onnx(
 quant_setting = QuantizationSettingFactory.pplcuda_setting()
 quant_setting.equalization = True # use layerwise equalization algorithm.
 quant_setting.dispatcher   = 'conservative' # dispatch this network in conservertive way.
-
-quant_setting.advanced_optimization = True # use advanced optimization procedure
 
 # load graph from disk
 # For pytorch user, just dump your network to disk with onnx first

--- a/ppq/samples/dynamic_shape.py
+++ b/ppq/samples/dynamic_shape.py
@@ -1,0 +1,29 @@
+# This example shows how to make a dynamic-shape network
+# dynamic shape is only supported by onnx
+
+# first of all, load your model from anywhere
+from ppq import *
+from ppq.api import *
+
+YOU_WANT_TO_QUANTIZE_IT = True
+
+ir = load_onnx_graph('onnx model path')
+input_shape = [1, 3, 224, 224]
+samples     = [torch.zeros(size=input_shape).cuda()]
+
+if YOU_WANT_TO_QUANTIZE_IT:
+    ir = dispatch_graph(ir, platform=TargetPlatform.NCNN_INT8, 
+                        setting=QuantizationSettingFactory.ncnn_setting())
+
+    ir = quantize_native_model(
+        model=ir, calib_dataloader=samples, calib_steps=32, 
+        input_shape=input_shape, setting=QuantizationSettingFactory.ncnn_setting())
+
+# You are supposed to set dynamic shape input/output variable just before export.
+# Get variable instance from ir by its name, set shape attribute as your wish.
+var = ir.variables['input variable name']
+var.shape = ['Batch', 3, 'Width', 'Height']
+# text, None, int are both acceptable here.
+
+export_ppq_graph(graph=ir, platform=TargetPlatform.NCNN_INT8, 
+                 graph_save_to='onnx model save to', config_save_to='config save to')

--- a/ppq/samples/onnx_converter.py
+++ b/ppq/samples/onnx_converter.py
@@ -1,0 +1,13 @@
+import onnx
+from onnx import version_converter, helper
+
+# Preprocessing: load the model to be converted.
+model_path = 'models/mbfill.onnx'
+original_model = onnx.load(model_path)
+
+# A full list of supported adapters can be found here:
+# https://github.com/onnx/onnx/blob/main/onnx/version_converter.py#L21
+# Apply the version conversion on the original model
+converted_model = version_converter.convert_version(original_model, 11)
+
+onnx.save(converted_model, 'models/mbfill_11.onnx')

--- a/ppq/scheduler/core/default.py
+++ b/ppq/scheduler/core/default.py
@@ -11,7 +11,8 @@ def CEHCK_TYPE(op: Operation, t: str):
 
 def CHECK_OPSET(min_version_supported: int, 
                 max_version_supported: int, 
-                op: Operation, strict_check: bool = STRICT_OPSET_CHECKING):
+                op: Operation, 
+                strict_check: bool = STRICT_OPSET_CHECKING):
     opset = op.opset
     if opset.domain != ONNX_DOMAIN:
         if not strict_check:

--- a/ppq/scheduler/perseus.py
+++ b/ppq/scheduler/perseus.py
@@ -1,9 +1,7 @@
 from typing import Dict, List, Set
 
 from ppq.core import TargetPlatform, ppq_warning
-from ppq.IR import BaseGraph, Operation
-from ppq.IR.search import SearchableGraph
-from ppq.scheduler.core.opsocket import OType
+from ppq.IR import BaseGraph, Operation, SearchableGraph
 
 from .base import GraphDispatcher
 from .core import (DEFAULT_SOCKET_CREATOR, DEFAULT_SOCKET_TABLE, OpSocket,
@@ -57,7 +55,7 @@ class Perseus(GraphDispatcher):
         """ 
         self.sockets   = {}
         self.verbose   = verbose
-        self.graph  = graph
+        self.graph     = graph
         self._search_engine = SearchableGraph(graph)
         self._precomputed_op_fanout = {}
         self._precomputed_op_fanin  = {}
@@ -109,7 +107,7 @@ class Perseus(GraphDispatcher):
         而后从 Shape, TopK 等节点出发，求解非计算节点的传递闭包 B
         
         集合 A - B 中的节点将被量化，也被称为量化区节点
-        集合 A * B 中的节点将被称为冲突去节点，默认不量化
+        集合 A * B 中的节点将被称为冲突区节点，默认不量化
         集合 B 中的节点将被称为 SOI 节点，不量化且调度到 Cpu 执行
         集合 A, B 之外的节点为未知区域节点，默认不量化
         

--- a/ppq/utils/ema.py
+++ b/ppq/utils/ema.py
@@ -1,0 +1,16 @@
+from math import pow
+
+class EMARecorder():
+    """Exponential Moving Average(EMA) with bias correction."""
+    def __init__(self, beta: float = 0.98):
+        self.beta  = beta
+        self.t     = 0
+        self.value = 0
+
+    def push(self, value: float):
+        self.value = (1.0 - self.beta) * value + self.beta * self.value
+        self.t += 1
+
+    def pop(self) -> float:
+        if self.t == 0: return 0
+        return self.value / (1 - pow(self.beta, self.t))


### PR DESCRIPTION
* Analyzer
    * 添加了新的分析方法 statistical_analyse
* API
    * 添加了新的api: load_native_graph
    * 修正了ppl cuda参数设置的小错误
* Executor
    * 支持1d, 3d卷积,
    * 支持1d 3d pooling
    * 支持1d 3d 反卷积
    * 支持 lstm, gru
    * 支持 sin, cos
    * 支持 abs
    * 支持 sum
    * 移除了注册算子的限制条件，现在你可以覆盖ppq内部的算子实现
* Dispatcher
    * 子图切分方法更改为 pursus，子图切分算法**参数暂时失效**
    * 添加调度报警信息，不允许执行未调度的计算图
* Observer
    * 添加了新的calibration方法OrderPreserving，保序量化将被应用在分类网络当中，提升分类性能
* Graph
    * 支持1d, 3d卷积与反卷积的bn融合
    * 修复了一个 caffe 算子 Opset 的 bug
    * Variable添加属性 shape，可以直接修改 shape 来设定 dynamic shape
* Other
    * 重新设计的ppq.core的import，避免污染
    * 为导出 qdq onnx 添加了一个可设置的参数 EXPORT_OVERLAPPED_CONFIG, 当设置为 True 时导出所有状态为overlap的qdq节点
    * 对 advanced optimization pass 进行升级，现在是一个完整的 cuda 版的lsq，加入了scale训练的功能
    * 移除了一些不必要的报警，例如 scale < 1e-8
    * 修改了一些属性名字，并将它们写入 ppq.common.py
    * 修复了 native export 的一些问题
    * 允许导出图时将图复制