### PR TITLE
解除一些自定义量化规则的限制

### DIFF
--- a/ppq/parser/onnxruntime_exporter.py
+++ b/ppq/parser/onnxruntime_exporter.py
@@ -229,6 +229,14 @@ class ONNXRUNTIMExporter(OnnxExporter):
             graph.create_link_with_var(input_var, output_var)
         return graph
 
+    def remove_branch_duplicated_quant_dequant_op(self, graph: BaseGraph) -> BaseGraph:
+        for variable in graph.variables.values():
+            if len(variable.dest_ops) < 1: continue
+            if all([op.type == 'QuantizeLinear' for op in variable.dest_ops]):
+                # check if has the same scale and offset
+                pass
+
+
     @ property
     def required_opsets(self) -> Dict[str, int]:
         extra_domain_versions = [('ai.onnx', 13)]

--- a/ppq/quantization/quantizer/TRTQuantizer.py
+++ b/ppq/quantization/quantizer/TRTQuantizer.py
@@ -27,9 +27,9 @@ class TensorRTQuantizer(BaseQuantizer):
             quant_max=self._quant_max, quant_min=self._quant_min,
             observer_algorithm='percentile'
         )
-        base_quant_config.output_quantization_config[0].state = QuantizationStates.FP32
 
         if operation.type in {'Conv', 'ConvTranspose', 'Gemm', 'MatMul'}:
+            base_quant_config.output_quantization_config[0].state = QuantizationStates.FP32
             # set all parameters within Conv, ConvTranspose, Gemm to per-channel quant-config.
             assert operation.num_of_input > 0, 'Seems you got a Conv layer with no parameters.'
 

--- a/ppq/quantization/quantizer/base.py
+++ b/ppq/quantization/quantizer/base.py
@@ -128,7 +128,8 @@ class BaseQuantizer(metaclass = ABCMeta):
             if operation.meta_data is None:
                 raise ValueError(f'Operation {op_name} has no meta data yet. calling executor.tracing_meta')
 
-            if operation.type in quantable_operation_types:
+            if operation.type in quantable_operation_types or TargetPlatform.is_quantized_platform(operation.platform):
+                # TargetPlatform.is_quantized_platform(operation.platform) means override.
                 if op_name in operation_quantization_configs: continue
                 else: operation_quantization_configs[op_name] = (
                     self.init_quantize_config(operation=operation)


### PR DESCRIPTION
* 解除trt导出时的限制，现在你可以导出任意qdq节点，不再仅限于导出计算节点的qdq信息
* 解除量化器的限制，现在允许你为非量化类型初始化量化信息(手动覆盖)
* 添加了一个 onnxruntime QDQ 导出时候的优化，可以合并不同分支上的 QDQ 节点，还在施工当中