### PR TITLE
onnx 模型导出与算法更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ PPQ 被设计为一个灵活而全面的神经网络离线量化工具，我们�
 |  |  | |
 | 08 | 创建我们自己的量化规则！了解目标平台与量化器 | [platform](https://github.com/openppl-public/ppq/blob/master/ppq/samples/Tutorial/targetPlatform.py) |
 | 09 | 自定义量化优化过程 | [Optim](https://github.com/openppl-public/ppq/blob/master/ppq/samples/Tutorial/optimization.py) |
+| 10 | 自定义图融合过程与量化管线 | [Fusion](https://github.com/openppl-public/ppq/blob/master/ppq/samples/Tutorial/fusion.py) |
 
 ### PPQ Optim 优化过程文档
 | | **Description 介绍** | **Link 链接** |

--- a/ppq/IR/base/graph.py
+++ b/ppq/IR/base/graph.py
@@ -234,7 +234,9 @@ class Variable(Serializable):
                         'however its value is not an instance of torch.Tensor, '
                         'ppq will automaticall convert it to torch.Tensor now.')
             self.value = convert_any_to_torch_tensor(self.value)
-        return Variable(name=self.name, value=self.value.clone(), is_parameter=self.is_parameter)
+        if isinstance(self.value, torch.Tensor):
+            value = self.value.clone()
+        return Variable(name=self.name, value=value, is_parameter=self.is_parameter)
 
 
 class Operation(OperationBase, Serializable):

--- a/ppq/api/interface.py
+++ b/ppq/api/interface.py
@@ -157,7 +157,7 @@ def dump_torch_to_onnx(
     model: torch.nn.Module,
     onnx_export_file: str,
     input_shape: List[int],
-    input_dtype: torch.dtype,
+    input_dtype: torch.dtype = torch.float,
     inputs: List[Any] = None,
     device: str = 'cuda'):
     """

--- a/ppq/core/common.py
+++ b/ppq/core/common.py
@@ -2,7 +2,6 @@
 # PPQ System configuration
 # You can modify following codes for your own purpose.
 
-
 # Observer 中，最小 scale 限制，所有小于该值的 scale 将被该值覆盖
 OBSERVER_MIN_SCALE = 1e-8
 # Observer 中，最小 scale 的手动覆盖属性
@@ -64,9 +63,6 @@ DEFAULT_OPSET_DOMAIN  = 'ai.onnx'
 DEFAULT_OPSET_VERSION = 11
 STRICT_OPSET_CHECKING = False
 
-# 导出 qdq 节点时是否需要导出状态已经是 overlap 的节点
-EXPORT_OVERLAPPED_CONFIG = False
-
 # LSTM 算子的权重缓存属性
 LSTM_FLATTEN_WEIGHT_ATTRIB = 'LSTM_FLATTEN_WEIGHT_ATTRIB'
 # GRU 算子的权重缓存属性
@@ -91,3 +87,6 @@ CHECKPOINT_TOLERANCE = 1
 
 # 要做 Bias Correction 的算子种类
 BIAS_CORRECTION_INTERST_TYPE = {'Conv', 'Gemm', 'ConvTranspose'}
+
+# 导出 qdq 节点时是否需要导出状态已经是 overlap 的节点
+EXPORT_OVERLAPPED_CONFIG = False

--- a/ppq/parser/caffe_exporter.py
+++ b/ppq/parser/caffe_exporter.py
@@ -40,12 +40,7 @@ class CaffeExporter(GraphExporter):
         for operation in graph.operations.values():
             if not isinstance(operation, QuantableOperation): continue
             for config, var in operation.config_with_variable:
-                if not QuantizationStates.can_export(config.state):
-                    raise PermissionError(
-                        'Can not export quant config cause not all quantization configurations '
-                        'have been correctly initialized(or some of them has been deactivated). '
-                        f'Operation {operation.name} has an invalid quantization config({config.state}) '
-                        f'at variable {var.name}.')
+                if not config.can_export(): continue
 
                 # PATCH 2021.11.25
                 # REMOVE BIAS FROM CONFIGURATION

--- a/ppq/parser/ncnn_exporter.py
+++ b/ppq/parser/ncnn_exporter.py
@@ -18,6 +18,8 @@ class NCNNExporter(GraphExporter):
             if op.is_computing_op and isinstance(op, QuantableOperation):
                 fd.write(f'{op.name}_param_0 ')
                 param_cfg = op.config.input_quantization_config[1]
+                if not param_cfg.can_export(): continue
+
                 assert param_cfg.state in {QuantizationStates.BAKED, QuantizationStates.ACTIVATED}\
                     and param_cfg.observer_algorithm in {'minmax', 'Minmax'} and \
                         param_cfg.policy.has_property(QuantizationProperty.PER_CHANNEL)
@@ -32,6 +34,7 @@ class NCNNExporter(GraphExporter):
                 for s in scale:
                     fd.write('%f '% s)
                 fd.write('\n')
+
         for op in topo_order:
             if op.is_computing_op and isinstance(op, QuantableOperation):
                 fd.write(f'{op.name} ')

--- a/ppq/parser/nxp_exporter.py
+++ b/ppq/parser/nxp_exporter.py
@@ -63,9 +63,8 @@ class NxpExporter(GraphExporter):
                 if variable.is_parameter and not export_param: continue
                 for config in configs:
                     if config is None: continue # source_op can be None
-                    if config.state in {QuantizationStates.ACTIVATED, QuantizationStates.BAKED,
-                                        QuantizationStates.OVERLAPPED, QuantizationStates.PASSIVE_BAKED}:
-                        if config.state == QuantizationStates.OVERLAPPED: config = config.dominated_by
+                    if config.can_export():
+
                         tensor_range = config.scale * pow(2, config.num_of_bits - 1)
                         min_val, max_val = -tensor_range, tensor_range - config.scale
                         min_tensor = numpy_helper.from_array(

--- a/ppq/parser/onnxruntime_oos_exporter.py
+++ b/ppq/parser/onnxruntime_oos_exporter.py
@@ -2,12 +2,11 @@
 from typing import List, Tuple
 
 import torch
-from ppq.IR.search import SearchableGraph
-from ppq.core import (PASSIVE_OPERATIONS, DataType, QuantizationStates,
-                      TensorMeta, TensorQuantizationConfig,
-                      convert_any_to_torch_tensor, ppq_warning)
+from ppq.core import (DataType, QuantizationStates, TargetPlatform, TensorMeta,
+                      TensorQuantizationConfig, convert_any_to_torch_tensor,
+                      ppq_warning)
 from ppq.IR import BaseGraph, Operation, QuantableOperation, Variable
-from ppq.core.quant import TargetPlatform
+from ppq.IR.search import SearchableGraph
 from ppq.quantization.qfunction.linear import PPQLinearQuant_toInt
 from ppq.utils.round import ppq_tensor_round
 

--- a/ppq/parser/ppl.py
+++ b/ppq/parser/ppl.py
@@ -15,18 +15,14 @@ def convert_type(platform: TargetPlatform) -> str:
     if platform == TargetPlatform.FP32: return None
     raise TypeError(f'Unsupported platform type. ({str(platform)})')
 
+
 class PPLBackendExporter(OnnxExporter):
     def export_quantization_config(self, config_path: str, graph: BaseGraph):
         var_quant_info_recorder, op_platform_recorder = {}, {}
         for operation in graph.operations.values():
             if not isinstance(operation, QuantableOperation): continue
             for config, var in operation.config_with_variable:
-                if not QuantizationStates.can_export(config.state):
-                    raise PermissionError(
-                        'Can not export quant config cause not all quantization configurations '
-                        'have been correctly initialized(or some of them has been deactivated). '
-                        f'Operation {operation.name} has an invalid quantization state({config.state}) '
-                        f'at variable {var.name}.')
+                if not config.can_export(): continue
 
                 # PATCH 2021.11.25
                 # REMOVE BIAS FROM CONFIGURATION

--- a/ppq/quantization/algorithm/equalization.py
+++ b/ppq/quantization/algorithm/equalization.py
@@ -1,9 +1,8 @@
 from enum import Enum
-from typing import List, Tuple
+from typing import List
 
 import torch
 from ppq.IR import Operation
-from tqdm import tqdm as Progressbar
 
 
 class EqualizationMethod(Enum):
@@ -22,386 +21,268 @@ class EqualizationMethod(Enum):
     SQUARE_MEAN = 4,
 
 
+class EqualizationHelper():
+
+    @ staticmethod
+    def key_value_from_upstream(
+        op: Operation, including_bias: bool = False, including_act: bool = False, 
+        bias_multiplier: float = 0.5, act_multiplier: float = 0.5) -> torch.Tensor:
+        if op.type not in {'Gemm', 'MatMul', 'Conv', 'ConvTranspose'}:
+            raise TypeError(f'Unsupported Op type {op.name}({op.type}) for Equalization Optimization.')
+        if not op.inputs[1].is_parameter:
+            raise ValueError(f'Parameter of Op {op.name} is non-static.')
+        buffer = []
+
+        # ----------------------------------
+        # step - 1, extract weight from op:
+        # ----------------------------------
+        w = op.inputs[1].value
+        if op.type == 'ConvTranspose':
+            num_of_groups = op.attributes.get('group', 1)
+            if w.ndim == 3:
+                w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+                w = torch.permute(w, (2, 0, 1, 3))
+                w = torch.reshape(w, (w.shape[0] * w.shape[1], -1))
+            elif w.ndim == 4:
+                w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+                w = torch.permute(w, (2, 0, 1, 3, 4))
+                w = torch.reshape(w, (w.shape[0] * w.shape[1], -1))
+            elif w.ndim == 5:
+                w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+                w = torch.permute(w, (2, 0, 1, 3, 4, 5))
+                w = torch.reshape(w, (w.shape[0] * w.shape[1], -1))
+            else:
+                raise ValueError(f'Unexpected dimension of weight of {op.name}.')
+            buffer.append(w)
+
+        if op.type in {'MatMul', 'Gemm'}:
+            assert w.ndim == 2, f'Unexpected Error, Parameter of MatMul {op.name} should be 2-d.'
+            if op.attributes.get('transB', 0) == 0:
+                w = torch.transpose(w, 1, 0)
+            buffer.append(w)
+
+        if op.type == 'Conv':
+            w = torch.reshape(w, (w.shape[0], -1))
+            buffer.append(w)
+
+        # ----------------------------------
+        # step - 2, extract bias from op:
+        # ----------------------------------
+        if including_bias and op.num_of_input == 3:
+            b = op.inputs[-1].value * bias_multiplier
+            if op.type in {'Conv', 'Gemm'} and op.inputs[-1].is_parameter:
+                b = torch.reshape(b, (w.shape[0], 1))
+                buffer.append(b)
+
+            if op.type == 'ConvTranspose':
+                b = torch.reshape(b, (w.shape[0], 1))
+                buffer.append(b)
+
+        # ----------------------------------
+        # step - 3, extract activation from op:
+        # ----------------------------------
+        if including_act and op.inputs[0].value is not None:
+            a = op.outputs[0].value * act_multiplier
+            buffer.append(a)
+
+        # concat and return
+        return torch.cat(buffer, dim=-1)
+
+    @ staticmethod
+    def key_value_from_downstream(op: Operation) -> torch.Tensor:
+        # ----------------------------------
+        # step - 1, extract weight from op:
+        # ----------------------------------
+        w = op.inputs[1].value
+        if op.type == 'ConvTranspose':
+            w = torch.reshape(w, (w.shape[0], -1))
+
+        if op.type in {'MatMul', 'Gemm'}:
+            assert w.ndim == 2, f'Unexpected Error, Parameter of MatMul {op.name} should be 2-d.'
+            if op.attributes.get('transB', 0) != 0:
+                w = torch.transpose(w, 1, 0)
+
+        if op.type == 'Conv':
+            # for group convolution, we have to select its weight by group
+            num_of_groups = op.attributes.get('group', 1)
+            if w.ndim == 3:
+                w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+                w = torch.permute(w, (2, 0, 1, 3))
+                w = torch.reshape(w, (w.shape[0] * w.shape[1], -1))
+            elif w.ndim == 4:
+                w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+                w = torch.permute(w, (2, 0, 1, 3, 4))
+                w = torch.reshape(w, (w.shape[0] * w.shape[1], -1))
+            elif w.ndim == 5:
+                w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+                w = torch.permute(w, (2, 0, 1, 3, 4, 5))
+                w = torch.reshape(w, (w.shape[0] * w.shape[1], -1))
+            else:
+                raise ValueError(f'Unexpected dimension of weight of {op.name}.')
+        return w
+
+    @ staticmethod
+    def scale_to_upstream(op: Operation, scale_factor: torch.Tensor):
+        if op.type not in {'Gemm', 'MatMul', 'Conv', 'ConvTranspose'}:
+            raise TypeError(f'Unsupported Op type {op.name}({op.type}) for Equalization Optimization.')
+        if not op.inputs[1].is_parameter:
+            raise ValueError(f'Parameter of Op {op.name} is non-static.')
+
+        w = op.inputs[1].value
+        has_bias = op.num_of_input == 3
+        if has_bias and not op.inputs[-1].is_parameter: 
+            raise ValueError(f'Bias of Op {op.name} is non-static.')
+        if has_bias: bias = op.inputs[-1].value
+
+        if op.type == 'ConvTranspose':
+            num_of_groups = op.attributes.get('group', 1)
+            w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1:])
+            w *= torch.reshape(scale_factor, [num_of_groups, 1, -1] + [1] * (w.ndim - 3))
+            w = torch.reshape(w, (w.shape[0] * w.shape[1], ) + w.shape[2:])
+            if has_bias: bias *= scale_factor
+
+        elif op.type == 'Conv':
+            w *= torch.reshape(scale_factor, [-1] + ([1] * (w.ndim - 1)))
+            if has_bias: bias *= scale_factor
+
+        elif op.type in {'Gemm', 'MatMul'}:
+            if op.attributes.get('transB', 0) == 0: w = torch.transpose(w, 1, 0)
+            w *= torch.reshape(scale_factor, (-1, 1))
+            if op.attributes.get('transB', 0) == 0: w = torch.transpose(w, 1, 0)
+            if has_bias: bias *= scale_factor
+        
+        # write back
+        with torch.no_grad():
+            op.inputs[1].value.copy_(w)
+            if has_bias: op.inputs[-1].value.copy_(bias)
+
+    @ staticmethod
+    def scale_to_downstream(op: Operation, scale_factor: torch.Tensor):
+        if op.type not in {'Gemm', 'MatMul', 'Conv', 'ConvTranspose'}:
+            raise TypeError(f'Unsupported Op type {op.name}({op.type}) for Equalization Optimization.')
+        if not op.inputs[1].is_parameter:
+            raise ValueError(f'Parameter of Op {op.name} is non-static.')
+        w = op.inputs[1].value
+
+        if op.type == 'ConvTranspose':
+            w /= torch.reshape(scale_factor, [-1] + ([1] * (w.ndim - 1)))
+
+        if op.type == 'Conv':
+            num_of_groups = op.attributes.get('group', 1)
+            w = torch.reshape(w, (num_of_groups, w.shape[0] // num_of_groups) + w.shape[1: ])
+            w /= torch.reshape(scale_factor, [num_of_groups, 1, -1] + [1] * (w.ndim - 3))
+            w = torch.reshape(w, (w.shape[1] * num_of_groups, ) + w.shape[2: ])
+
+        if op.type in {'Gemm', 'MatMul'}:
+            if op.attributes.get('transB', 0) != 0: w = torch.transpose(w, 1, 0)
+            w /= torch.reshape(scale_factor, (-1, 1))
+            if op.attributes.get('transB', 0) != 0: w = torch.transpose(w, 1, 0)
+
+        # write back
+        with torch.no_grad():
+            op.inputs[1].value.copy_(w)
+
+
 class EqualizationPair:
     def __init__(
         self,
-        all_upstream_layers: List[Operation],
-        all_downstream_layers: List[Operation],
-        method:EqualizationMethod=EqualizationMethod.ABSOLUTE_MAX
+        upstream_layers: List[Operation],
+        downstream_layers: List[Operation]
     ):
         """
-
             EqualizationPair - 一个数据结构，封装了 equalization 的核心数据抽象和执行逻辑
                                a class encapsulating execution logic of equalization
 
-                在 self.all_upstream_layers 包含了 equalization 操作中的所有上游层(op)
-                self.all_upstream_layers contain all upstream ops
+                在 self.upstream_layers 包含了 equalization 操作中的所有上游层(op)
+                self.upstream_layers contain all upstream ops
 
-                在 self.all_downstream_layers 包含了 equalization 操作中的所有下游层(op)
-                self.all_downstream_layers contain all downstream ops
+                在 self.downstream_layers 包含了 equalization 操作中的所有下游层(op)
+                self.downstream_layers contain all downstream ops
 
             一个 EqualizationPair 结构记录了参与 equalization 变换的所有相关层与其局部图结构信息
             从而支持在局部子图上的 equalization 操作
             An EqualizationPair records all relevant ops participating in the equalization
             transformation, thus supporting equalization on local subgraphs
         Args:
-            all_upstream_layers (list):
+            upstream_layers (list):
                 equalization 操作中的所有上游层(op)
 
-            all_downstream_layers (list):
+            downstream_layers (list):
                 equalization 操作中的所有下游层(op)
-
-            method (EqualizationMethod, optional):
-                equalization 操作中，变换系数 s 的计算方式. Defaults to EqualizationMethod.ABSOLUTE_MAX.
-
         """
-        self.upstream_layers = all_upstream_layers
-        self.downstream_layers = all_downstream_layers
-        self.method = method
+        self.upstream_layers = upstream_layers
+        self.downstream_layers = downstream_layers
 
-    def extract_key_value(self, including_bias: bool) -> Tuple[torch.Tensor, torch.Tensor]:
-        # extract all params from upstream_layers
-        upstream_params, downstream_params = [], []
-        for upstream_layer in self.upstream_layers:
-            assert upstream_layer.type in ('Conv', 'ConvTranspose', 'Gemm'), (
-            'Only Conv or Linear layer is support in layerwise equalization now, '
-            'but %s got' % upstream_layer.type)
-
-            if upstream_layer.type == 'ConvTranspose':
-                # weight shape is: [input channel, output channel / group, kernel, kernel]
-                weight, bias = self.get_convtranspose2d_params(upstream_layer, including_bias)
-                num_of_groups = upstream_layer.attributes.get('group', 1)
-                weight = torch.reshape(weight, (num_of_groups, weight.shape[0] // num_of_groups) + weight.shape[1:])
-                weight = weight.permute(0, 2, 1, 3, 4)
-                weight = weight.reshape(weight.shape[0] * weight.shape[1], -1)
-
-                upstream_params.append(weight)
-                if including_bias and bias is not None:
-                    upstream_params.append(torch.reshape(bias, (weight.shape[1] * num_of_groups, 1)))
-
-            elif upstream_layer.type == 'Conv':
-                # weight shape is: [output channel, input channel, kernel, kernel]
-                weight, bias = self.get_conv2d_params(upstream_layer, including_bias)
-                weight = torch.reshape(weight, (weight.shape[0], -1))
-
-                upstream_params.append(weight)
-                if including_bias and bias is not None:
-                    upstream_params.append(torch.reshape(bias, (weight.shape[0], 1)))
-
-            elif upstream_layer.type == 'Gemm':
-                # weight shape is: [output channel, input channel]
-                weight, bias = self.get_linear_params(upstream_layer, including_bias)
-
-                upstream_params.append(weight)
-                if including_bias and bias is not None:
-                    upstream_params.append(torch.reshape(bias, (weight.shape[0], 1)))
-
-        # extract all params from downstream_layers
-        for downstream_layer in self.downstream_layers:
-            assert downstream_layer.type in ('Conv', 'ConvTranspose', 'Gemm'), (
-            'Only Conv or Linear layer is support in layerwise equalization now, '
-            'but %s got' % downstream_layer.type)
-
-            if downstream_layer.type == 'Conv':
-                # weight shape is: [output channel, input channel // num_of_groups, kernel, kernel]
-                weight, bias = self.get_conv2d_params(downstream_layer, False)
-
-                # for group convolution, we have to select its weight by group
-                num_of_groups = downstream_layer.attributes.get('group', 1)
-
-                weight = torch.reshape(weight, (num_of_groups, weight.shape[0] // num_of_groups) + weight.shape[1: ])
-                weight = weight.permute(2, 0, 1, 3, 4)
-                weight = torch.reshape(weight, (weight.shape[0] * weight.shape[1], -1))
-
-                downstream_params.append(weight)
-
-            elif downstream_layer.type == 'ConvTranspose':
-                # weight shape is: [input channel, output channel // num_of_groups, kernel, kernel]
-                weight, bias = self.get_convtranspose2d_params(downstream_layer, False)
-
-                # for group convolution, we have to select its weight by group
-                num_of_groups = downstream_layer.attributes.get('group', 1)
-
-                weight = torch.reshape(weight, (weight.shape[0], -1))
-
-                downstream_params.append(weight)
-
-            elif downstream_layer.type == 'Gemm':
-                # weight shape is: [output channel, input channel]
-                weight, bias = self.get_linear_params(downstream_layer, False)
-                downstream_params.append(weight.permute(1, 0))
-
-        # format all params
-        upstream_key_values   = self.reduce_by_axis(upstream_params, method=self.method, aggerate_axis=1)
-        downstream_key_values = self.reduce_by_axis(downstream_params, method=self.method, aggerate_axis=1)
-        return upstream_key_values, downstream_key_values
-
-    def layerwise_equalize(
+    def equalize(
         self,
         value_threshold: float,
-        including_bias: bool
+        including_act: bool = False,
+        act_multiplier: float = 0.5,
+        including_bias: bool = False,
+        bias_multiplier: float = 0.5,
+        method: EqualizationMethod = EqualizationMethod.ABSOLUTE_MAX
     ):
         # extract key value from pair
-        upstream_key_values, downstream_key_values = self.extract_key_value(including_bias=including_bias)
+        upstream_key_values, downstream_key_values = [], []
+        for op in self.upstream_layers:
+            key_value = EqualizationHelper.key_value_from_upstream(
+                op=op, including_bias=including_bias, including_act=including_act, 
+                bias_multiplier=bias_multiplier, act_multiplier=act_multiplier)
+            upstream_key_values.append(key_value)
+
+        for op in self.downstream_layers:
+            key_value = EqualizationHelper.key_value_from_downstream(op=op)
+            downstream_key_values.append(key_value)
+
+        upstream_key_values   = self.reduce_by_axis(upstream_key_values, method=method)
+        downstream_key_values = self.reduce_by_axis(downstream_key_values, method=method)
 
         # calculate scale
         scale = self.calculate_scale(
             upstream_key_values=upstream_key_values,
             downstream_key_values=downstream_key_values,
-            minval_threshold=value_threshold
-        )
+            value_threshold=value_threshold)
 
         # write back all params
-        for upstream_layer in self.upstream_layers:
-            if upstream_layer.type == 'ConvTranspose':
-                weight, bias = self.get_convtranspose2d_params(upstream_layer, True)
-                num_of_groups = upstream_layer.attributes.get('group', 1)
-                weight = torch.reshape(weight, (num_of_groups, weight.shape[0] // num_of_groups) + weight.shape[1:])
-                weight *= torch.reshape(scale, (num_of_groups, 1, -1, 1, 1))
-                weight = torch.reshape(weight, (weight.shape[0] * weight.shape[1], ) + weight.shape[2:])
-                if bias is not None:
-                    bias *= scale
-                self.set_convtranspose2d_params(upstream_layer, bias, weight)
+        for op in self.upstream_layers:
+            EqualizationHelper.scale_to_upstream(op, scale)
 
-            elif upstream_layer.type == 'Conv':
-                weight, bias = self.get_conv2d_params(upstream_layer, True)
-                weight *= torch.reshape(scale, (-1, 1, 1, 1))
-                if bias is not None:
-                    bias *= scale
-                self.set_conv2d_params(upstream_layer, bias, weight)
+        for op in self.downstream_layers:
+            EqualizationHelper.scale_to_downstream(op, scale)
 
-            elif upstream_layer.type == 'Gemm':
-                weight, bias = self.get_linear_params(upstream_layer, True)
-                weight *= torch.reshape(scale, (-1, 1))
-                if bias is not None:
-                    bias *= scale
-                self.set_linear_params(upstream_layer, bias, weight)
-
-        for downstream_layer in self.downstream_layers:
-
-            if downstream_layer.type == 'ConvTranspose':
-                weight, bias = self.get_convtranspose2d_params(downstream_layer, False)
-                # for group convolution, we have to select its weight by group
-
-                weight /= torch.reshape(scale, (-1, 1, 1, 1))
-                self.set_convtranspose2d_params(downstream_layer, bias, weight)
-
-            elif downstream_layer.type == 'Conv':
-                weight, bias = self.get_conv2d_params(downstream_layer, False)
-                # for group convolution, we have to select its weight by group
-                num_of_groups = downstream_layer.attributes.get('group', 1)
-
-                weight = torch.reshape(weight, (num_of_groups, weight.shape[0] // num_of_groups) + weight.shape[1: ])
-                weight /= torch.reshape(scale, (num_of_groups, 1, -1, 1, 1))
-                weight = torch.reshape(weight, (weight.shape[1] * num_of_groups, ) + weight.shape[2: ])
-                self.set_conv2d_params(downstream_layer, bias, weight)
-
-            elif downstream_layer.type == 'Gemm':
-                weight, bias = self.get_linear_params(downstream_layer, False)
-                weight /= torch.reshape(scale, (1, -1))
-
-                self.set_linear_params(downstream_layer, bias, weight)
-
-    def layerwise_channel_split(
-        self, value_threshold: float,
+    def channel_split(
+        self, 
+        value_threshold: float,
         including_bias: bool):
         pass
 
-    def display(self) -> str:
-        for layer in self.upstream_layers + self.downstream_layers:
-            if layer.type == 'Conv':
-                weight, bias = self.get_conv2d_params(layer, including_bias=True)
-            elif layer.type == 'Gemm':
-                weight, bias = self.get_linear_params(layer, including_bias=True)
-            else:
-                raise Exception('Expect conv layer or linear layer only, while %s was given.' % layer.type)
-
-            print('Stat of Layer %s: \t{%.4f}(Weight Max),\t{%.4f}(Weight Std)\t{%.4f}(Bias Max),\t{%.4f}(Bias Std)' % (
-                layer.name,
-                torch.max(torch.abs(weight)),
-                torch.std(weight),
-                torch.max(torch.abs(bias)) if bias is not None else 0,
-                torch.std(bias) if bias is not None else 0
-            ))
-        print('--- Layer-wise Equalization display end. ---')
-
-
-    def __str__(self) -> str:
-        return (
-            'Class EqualizationPair: '
-            '[all_upstream_layers: %s, all_downstream_layers: %s]' %
-            (self.upstream_layers, self.downstream_layers))
-
-
-    def get_conv2d_params(self, conv: Operation, including_bias: bool):
-
-        assert conv.type == 'Conv', (
-            'Except input object with type Conv, but %s got' % conv.type)
-        assert conv.inputs[1].is_parameter, (
-            f'Convolution layer {conv.name} has no static weights, please remove it from layerwise optimization.')
-        assert conv.inputs[1].value.ndim == 4, (
-            f'Convolution layer {conv.name} is not a 2-d convolution, '
-            'layerwise equalization or split with n-d convolution is not supported yet.')
-
-        weight, bias = conv.parameters[0].value, None
-        if including_bias and len(conv.parameters) > 1:
-            bias = conv.parameters[1].value
-
-        return weight, bias
-
-
-    def get_convtranspose2d_params(self, conv: Operation, including_bias: bool):
-
-        assert conv.type == 'ConvTranspose', (
-            'Except input object with type Conv, but %s got' % conv.type)
-        assert conv.inputs[1].is_parameter, (
-            f'Convolution layer {conv.name} has no static weights, please remove it from layerwise optimization.')
-        assert conv.inputs[1].value.ndim == 4, (
-            f'Convolution layer {conv.name} is not a 2-d convolution, '
-            'layerwise equalization or split with n-d convolution is not supported yet.')
-
-        weight, bias = conv.parameters[0].value, None
-        if including_bias and len(conv.parameters) > 1:
-            bias = conv.parameters[1].value
-
-        return weight, bias
-
-
-    def get_linear_params(self, linear: Operation, including_bias: bool):
-
-        assert linear.type == 'Gemm', (
-            'Except input object with type Gemm, but %s got' % linear.type)
-        assert linear.inputs[1].is_parameter, (
-            f'Linear layer {linear.name} has no static weights, please remove it from layerwise optimization.')
-
-        weight, bias = linear.parameters[0].value, None
-        if including_bias and len(linear.parameters) > 1:
-            bias = linear.parameters[1].value
-
-        if not linear.attributes.get('transB', 0):
-            weight = torch.transpose(weight, 1, 0)
-        if bias is not None: return weight, bias
-        else: return [weight, None]
-
-
-    def set_conv2d_params(self, conv: Operation, bias: torch.Tensor, weight: torch.Tensor):
-
-        assert conv.type == 'Conv', (
-            'Except input object with type Conv, but %s got' % conv.type)
-
-        conv.parameters[0].value = weight
-        if bias is not None and len(conv.parameters) > 1:
-            conv.parameters[1].value = bias
-
-
-    def set_convtranspose2d_params(self, conv: Operation, bias: torch.Tensor, weight: torch.Tensor):
-
-        assert conv.type == 'ConvTranspose', (
-            'Except input object with type Conv, but %s got' % conv.type)
-
-        conv.parameters[0].value = weight
-        if bias is not None and len(conv.parameters) > 1:
-            conv.parameters[1].value = bias
-
-
-    def set_linear_params(self, linear: Operation, bias: torch.Tensor, weight: torch.Tensor):
-
-        assert linear.type == 'Gemm', (
-            'Except input object with type Gemm, but %s got' % linear.type)
-
-        if not linear.attributes.get('transB', 0):
-            weight = torch.transpose(weight, 1, 0)
-        linear.parameters[0].value = weight
-        if bias is not None and len(linear.parameters) > 1:
-            linear.parameters[1].value = bias
-
-
     def calculate_scale(
-        self,
-        upstream_key_values: torch.Tensor,
+        self, upstream_key_values: torch.Tensor,
         downstream_key_values: torch.Tensor,
-        minval_threshold: float,
-        scale_clip_value: float = 10,
-    ):
+        value_threshold: float, scale_clip_value: float = 10):
         scale = 1 / torch.sqrt(upstream_key_values / downstream_key_values)
         scale = torch.clamp(scale, 1 / scale_clip_value, scale_clip_value)
-        scale[(upstream_key_values + downstream_key_values) < minval_threshold] = 1
-
+        scale[(upstream_key_values + downstream_key_values) < value_threshold] = 1
         return scale
-
 
     def reduce_by_axis(
         self,
         params: List[torch.Tensor],
         method: EqualizationMethod,
-        aggerate_axis: int=1,
+        axis: int=1,
     ) -> torch.Tensor:
-        params = torch.cat(params, axis=aggerate_axis)
+        params = torch.cat(params, axis=axis)
         if method is EqualizationMethod.ABSOLUTE_MAX:
-            return torch.max(torch.abs(params), axis=aggerate_axis)[0]
+            return torch.max(torch.abs(params), axis=axis)[0]
 
         elif method is EqualizationMethod.ABSOLUTE_MEAN:
-            return torch.mean(torch.abs(params), axis=aggerate_axis)
+            return torch.mean(torch.abs(params), axis=axis)
 
         elif method is EqualizationMethod.SQUARE_MAX:
-            return torch.max(torch.square(params), axis=aggerate_axis)[0]
+            return torch.max(torch.square(params), axis=axis)[0]
 
         elif method is EqualizationMethod.SQUARE_MEAN:
-            return torch.mean(torch.square(params), axis=aggerate_axis)
+            return torch.mean(torch.square(params), axis=axis)
 
         else:
             raise NotImplementedError('Equalization method %s is not support.' % str(method))
-
-
-def layerwise_equalization(
-    equalization_pairs: List[EqualizationPair],
-    weight_threshold: float = 0.5,
-    including_bias: bool = True,
-    iteration: int = 10,
-    verbose: bool = False
-):
-    """
-
-        layerwise_equalization - 层间权重均一化，使用该函数从大尺度上拉平各个层之间的权重与bias，从而使得量化结果更加精确
-                                this func equalizes weights and biases between differenr layers and reduces
-                                quantization error
-        一次 equalization 操作是指利用性质: C * ( AX + b ) = C/s * ( AsX + b )，所作的恒等变换，其中s为对角矩阵
-        one equalization step refers to use above formula to do equivalent transformation
-
-        通过上述变换以及精心选取的 s，可以使得权重矩阵 A, b, C 的数值大小尽可能接近，从而使得量化更加精准
-        we could make numerical ranges of weight matrice of different layers become as similar as possible by
-        choosing appropriate s, reducing quantization error, while preserving correct results
-
-        注意目前只支持关于 CONV, GEMM 的权重拉平策略
-        for now only CONV and GEMM support equalization
-        相关论文:
-
-        "Markus Nagel et al., Data-Free Quantization through Weight Equalization and Bias Correction" arXiv:1906.04721, 2019.
-
-    Args:
-        equalization_pairs (list): 所有需要被拉平的层的组合结构 all equalization pairs.
-        weight_threshold (float, optional): 参与权重均一化的最小权重 minimum weight for weight equalization defaults to 0.5.
-        including_bias (bool, optional): 是否执行带bias的权重均一化 whether to include bias defaults to True.
-        iteration (int, optional): 均一化执行次数 num of equalization iterations defaults to 10.
-        verbose (bool, optional): 是否输出均一化的相关结果，这将打印均一化前后的权重变化情况 whether to print details defaults to True.
-    """
-
-    if verbose:
-        for equalization_pair in equalization_pairs:
-            equalization_pair.display()
-
-    print(f'{len(equalization_pairs)} equalization pair(s) was found, ready to run optimization.')
-    for iter_times in Progressbar(range(iteration), desc='Layerwise Equalization', total=iteration):
-        for equalization_pair in equalization_pairs:
-            assert isinstance(equalization_pair, EqualizationPair), (
-                'Input equalization pairs should be encapsuled with class EqualizationPair')
-
-            equalization_pair.layerwise_equalize(
-                value_threshold=weight_threshold,
-                including_bias=including_bias
-            )
-
-    if verbose:
-        for equalization_pair in equalization_pairs:
-            equalization_pair.display()
-

--- a/ppq/quantization/optim/equalization.py
+++ b/ppq/quantization/optim/equalization.py
@@ -316,7 +316,9 @@ class LayerwiseEqualizationPass(QuantizationOptimizationPass):
         for idx, batch in tqdm(enumerate(dataloader),
                                desc='Equalization Data Collecting.',
                                total=min(len(dataloader), steps)):
-            data    = collate_fn(batch)
+            data = batch
+            if collate_fn is not None:
+                data = collate_fn(batch)
             outputs = executor.forward(data, output_names=output_names)
             for name, output in zip(output_names, outputs):
                 op = graph.variables[name].source_op

--- a/ppq/quantization/optim/refine.py
+++ b/ppq/quantization/optim/refine.py
@@ -422,12 +422,12 @@ class QuantizeFusionPass(QuantizationOptimizationPass):
                     ppq_warning(f'Unexpected dispatching was found: '
                                 f'Op {computing_op.name} and {act_op.name} should be send to a same platform.')
                     continue
-            
+
                 if not isinstance(act_op, QuantableOperation):
                     ppq_warning(f'Unexpected dispatching was found: '
                                 f'Op {computing_op.name} and {act_op.name} should both be quantized operation.')
                     continue
-                
+
                 assert isinstance(act_op, QuantableOperation)
                 if (len(graph.get_downstream_operations(computing_op)) == 1 and 
                     len(graph.get_upstream_operations(act_op)) == 1):
@@ -435,7 +435,7 @@ class QuantizeFusionPass(QuantizationOptimizationPass):
                         act_op.config.output_quantization_config[0])
                     act_op.config.input_quantization_config[0].dominated_by = (
                         act_op.config.output_quantization_config[0])
-            
+
             # fuse relu and clip if possible
             for op in graph.operations.values():
                 if op.type in {'Relu', 'Clip'}:
@@ -642,7 +642,9 @@ class QuantAlignmentPass(QuantizationOptimizationPass):
             elif operation.type in TYPES_FOR_ALIGNMENT['Pooling']:
                 if self.averagepool_method == 'None': continue
                 if self.averagepool_method == 'Align to Output':
-                    self.align_to_output(operation)
+                    master_config = self.align_to_output(operation)
+                if self.averagepool_method == 'Align to Large':
+                    raise ValueError('Alignment Method Error, Pooling Op can not align to lager input.')
 
             elif ALIGNMENT_MANUL_OVERRIDE in operation.extension_attrib:
                 method = operation.extension_attrib[ALIGNMENT_MANUL_OVERRIDE]

--- a/ppq/quantization/quantizer/DSPQuantizer.py
+++ b/ppq/quantization/quantizer/DSPQuantizer.py
@@ -73,7 +73,7 @@ class PPL_DSP_Quantizer(BaseQuantizer):
             'GlobalMaxPool', 'GlobalAveragePool', 'Softmax',
             'Mul', 'Add', 'Max', 'Sub', 'Div', 'Reshape',
             'LeakyRelu', 'Concat', 'Sigmoid', 'Slice', 'Interp',
-            'ReduceMean'}
+            'ReduceMean', 'Flatten'}
 
     @ property
     def quantize_policy(self) -> QuantizationPolicy:

--- a/ppq/quantization/quantizer/OpenvinoQuantizer.py
+++ b/ppq/quantization/quantizer/OpenvinoQuantizer.py
@@ -16,7 +16,7 @@ class OpenvinoQuantizer(BaseQuantizer):
     ) -> Union[torch.Tensor, list, dict]:
         super().__init__(graph=graph)
         self._num_of_bits = 8
-        self._quant_min = -127
+        self._quant_min = -128
         self._quant_max = 127
 
     def init_quantize_config(
@@ -35,7 +35,7 @@ class OpenvinoQuantizer(BaseQuantizer):
             # layout: [out_channel, in_channel, kernel_size, kernel_size]
             if operation.type in {'Conv', 'ConvTranspose'}:
                 conv_weight_config = base_quant_config.input_quantization_config[1]
-                conv_weight_config._quant_min = -127
+                conv_weight_config._quant_min = -128
                 conv_weight_config._quant_max = 127
                 conv_weight_config.policy = QuantizationPolicy(
                     QuantizationProperty.SYMMETRICAL +
@@ -52,7 +52,7 @@ class OpenvinoQuantizer(BaseQuantizer):
             # layout: [in_dim, out_dim]
             elif operation.type in {'Gemm'}:
                 gemm_weight_config = base_quant_config.input_quantization_config[1]
-                gemm_weight_config._quant_min = -127
+                gemm_weight_config._quant_min = -128
                 gemm_weight_config._quant_max = 127
                 gemm_weight_config.policy = QuantizationPolicy(
                     QuantizationProperty.SYMMETRICAL +

--- a/ppq/quantization/quantizer/base.py
+++ b/ppq/quantization/quantizer/base.py
@@ -375,9 +375,9 @@ class BaseQuantizer(metaclass = ABCMeta):
                 iterations           = equalization_setting.iterations,
                 weight_threshold     = equalization_setting.value_threshold,
                 including_bias       = equalization_setting.including_bias,
-                including_activation = equalization_setting.including_act,
-                bias_multiplier       = equalization_setting.bias_multiplier,
-                activation_multiplier = equalization_setting.act_multiplier
+                including_act        = equalization_setting.including_act,
+                bias_multiplier      = equalization_setting.bias_multiplier,
+                act_multiplier       = equalization_setting.act_multiplier
             ))
 
         return QuantizationOptimizationPipeline(passes=list_of_passes)

--- a/ppq/samples/Tutorial/fusion.py
+++ b/ppq/samples/Tutorial/fusion.py
@@ -1,0 +1,106 @@
+from typing import Callable, Iterable
+
+import torch
+import torchvision
+
+from ppq import (BaseGraph, QuantizationOptimizationPass,
+                 QuantizationOptimizationPipeline, QuantizationSetting,
+                 TargetPlatform, TorchExecutor)
+from ppq.api import ENABLE_CUDA_KERNEL
+from ppq.executor.torch import TorchExecutor
+from ppq.IR.quantize import QuantableOperation
+from ppq.IR.search import SearchableGraph
+from ppq.quantization.optim import (ParameterQuantizePass,
+                                    PassiveParameterQuantizePass,
+                                    QuantAlignmentPass, QuantizeRefinePass,
+                                    QuantizeSimplifyPass,
+                                    RuntimeCalibrationPass)
+from ppq.quantization.quantizer import TensorRTQuantizer
+
+# ------------------------------------------------------------
+# 在这个例子中，我们将向你介绍如何自定义量化优化过程，以及如何手动调用优化过程
+# ------------------------------------------------------------
+
+BATCHSIZE   = 32
+INPUT_SHAPE = [BATCHSIZE, 3, 224, 224]
+DEVICE      = 'cuda'
+PLATFORM    = TargetPlatform.TRT_INT8
+
+# ------------------------------------------------------------
+# 和往常一样，我们要创建 calibration 数据，以及加载模型
+# ------------------------------------------------------------
+def load_calibration_dataset() -> Iterable:
+    return [torch.rand(size=INPUT_SHAPE) for _ in range(32)]
+CALIBRATION = load_calibration_dataset()
+
+def collate_fn(batch: torch.Tensor) -> torch.Tensor:
+    return batch.to(DEVICE)
+
+model = torchvision.models.mobilenet.mobilenet_v2(pretrained=True)
+model = model.to(DEVICE)
+
+# ------------------------------------------------------------
+# 下面，我们将向你展示如何自定义图融合过程
+# 图融合过程将改变量化方案，PPQ 使用 Tensor Quantization Config
+# 来描述图融合的具体规则，其底层由并查集进行实现
+# ------------------------------------------------------------
+
+# ------------------------------------------------------------
+# 定义我们自己的图融合过程，在这里我们将尝试进行 Conv - Clip 的融合
+# 但与平常不同的是，我们将关闭 Clip 之后的量化点，保留 Conv - Clip 中间的量化
+# 对于更为复杂的模式匹配，你可以参考 ppq.quantization.optim.refine.SwishFusionPass
+# ------------------------------------------------------------
+class MyFusion(QuantizationOptimizationPass):
+    def optimize(self, graph: BaseGraph, dataloader: Iterable,
+                 collate_fn: Callable, executor: TorchExecutor, **kwargs) -> None:
+        
+        # 图融合过程往往由图模式匹配开始，让我们建立一个模式匹配引擎
+        search_engine = SearchableGraph(graph=graph)
+        for pattern in search_engine.pattern_matching(patterns=['Conv', 'Clip'], edges=[[0, 1]], exclusive=True):
+            conv, relu = pattern
+
+            # 匹配到图中的 conv - relu 对，接下来关闭不必要的量化点
+            # 首先我们检查 conv - relu 是否都是量化算子，是否处于同一平台
+            is_quantable = isinstance(conv, QuantableOperation) and isinstance(relu, QuantableOperation)
+            is_same_plat = conv.platform == relu.platform
+
+            if is_quantable and is_same_plat:
+                # 将 relu 输入输出的量化全部指向 conv 输出
+                # 一旦调用 dominated_by 完成赋值，则调用 dominated_by 的同时
+                # PPQ 会将 relu.input_quant_config[0] 与 relu.output_quant_config[0] 的状态置为 OVERLAPPED
+                # 在后续运算中，它们所对应的量化不再起作用
+                relu.input_quant_config[0].dominated_by = conv.output_quant_config[0]
+                relu.output_quant_config[0].dominated_by = conv.output_quant_config[0]
+
+# ------------------------------------------------------------
+# 自定义图融合的过程将会干预量化器逻辑，我们需要新建量化器
+# 此处我们继承 TensorRT Quantizer，算子的量化逻辑将使用 TensorRT 的配置
+# 但在生成量化管线时，我们将覆盖量化器原有的逻辑，使用我们自定义的管线
+# 这样我们就可以把自定义的图融合过程放置在合适的位置上，而此时 QuantizationSetting 也不再起作用
+# ------------------------------------------------------------
+class MyQuantizer(TensorRTQuantizer):
+    def build_quant_pipeline(self, setting: QuantizationSetting) -> QuantizationOptimizationPipeline:
+        return QuantizationOptimizationPipeline([
+            QuantizeRefinePass(),
+            QuantizeSimplifyPass(),
+            ParameterQuantizePass(),
+            MyFusion(name='My Optimization Procedure'),
+            RuntimeCalibrationPass(),
+            QuantAlignmentPass(),
+            PassiveParameterQuantizePass()])
+
+from ppq.api import quantize_torch_model, register_network_quantizer
+register_network_quantizer(quantizer=MyQuantizer, platform=TargetPlatform.EXTENSION)
+
+# ------------------------------------------------------------
+# 如果你使用 ENABLE_CUDA_KERNEL 方法
+# PPQ 将会尝试编译自定义的高性能量化算子，这一过程需要编译环境的支持
+# 如果你在编译过程中发生错误，你可以删除此处对于 ENABLE_CUDA_KERNEL 方法的调用
+# 这将显著降低 PPQ 的运算速度；但即使你无法编译这些算子，你仍然可以使用 pytorch 的 gpu 算子完成量化
+# ------------------------------------------------------------
+with ENABLE_CUDA_KERNEL():
+    quantized = quantize_torch_model(
+        model=model, calib_dataloader=CALIBRATION,
+        calib_steps=32, input_shape=INPUT_SHAPE,
+        collate_fn=collate_fn, platform=TargetPlatform.EXTENSION,
+        onnx_export_file='model.onnx', device=DEVICE, verbose=0)

--- a/tests/test_layerwise_equalization.py
+++ b/tests/test_layerwise_equalization.py
@@ -1,0 +1,236 @@
+from ppq import *
+from ppq.api import *
+import torch
+
+# 创建计算图
+graph = BaseGraph(name='Created Graph', built_from=NetworkFramework.NATIVE)
+op1 = graph.create_operation(
+    op_type='Gemm', name='Gemm1',
+    inputs=[graph.create_variable(), 
+            graph.create_variable(is_parameter=True, value=torch.rand(size=[128, 1024]).cuda() * 100), 
+            graph.create_variable(is_parameter=True, value=torch.rand(size=[1024]).cuda() * 100)],
+    outputs=[graph.create_variable()])
+
+op2 = graph.create_operation(
+    op_type='Gemm', name='Gemm2',
+    inputs=[op1.outputs[0], 
+            graph.create_variable(is_parameter=True, value=torch.rand(size=[1024, 128]).cuda()), 
+            graph.create_variable(is_parameter=True, value=torch.rand(size=[128]).cuda())],
+    outputs=[graph.create_variable()])
+
+op3 = graph.create_operation(
+    op_type='Gemm', name='Gemm3', attributes={'transB': 1},
+    inputs=[op2.outputs[0], 
+            graph.create_variable(is_parameter=True, value=torch.rand(size=[1024, 128]).cuda() * 500), 
+            graph.create_variable(is_parameter=True, value=torch.rand(size=[1024]).cuda() * 0)],
+    outputs=[graph.create_variable()])
+
+graph.mark_variable_as_graph_input(op1.inputs[0])
+graph.mark_variable_as_graph_output(op3.outputs[0])
+
+inputs   = [torch.rand(size=[8, 128]) for _ in range(32)]
+executor = TorchExecutor(graph=graph)
+b_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+b_outputs = torch.cat(b_outputs)
+
+from ppq.quantization.optim import LayerwiseEqualizationPass
+LayerwiseEqualizationPass(iterations=1000, including_bias=True, including_act=True).optimize(
+    graph=graph, dataloader=inputs, executor=executor, collate_fn=lambda x: x.cuda())
+p_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+p_outputs = torch.cat(p_outputs)
+from ppq.quantization.measure import torch_snr_error
+assert torch_snr_error(b_outputs, p_outputs).item() < 1e-7
+
+import torch
+class MyModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        with torch.no_grad():
+            self.conv1 = torch.nn.Conv2d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+            self.conv2 = torch.nn.Conv2d(in_channels=32, out_channels=32, groups=16, kernel_size=3, stride=1, padding=1, bias=False)
+            self.conv3 = torch.nn.Conv2d(in_channels=32, out_channels=8, groups=8, kernel_size=5, stride=1, padding=2)
+            self.convtranspose1 = torch.nn.ConvTranspose2d(in_channels=8, out_channels=32, kernel_size=5, stride=1, padding=2)
+            self.convtranspose2 = torch.nn.ConvTranspose2d(in_channels=32, out_channels=32, groups=32, kernel_size=3, stride=2, bias=False)
+            self.convtranspose3 = torch.nn.ConvTranspose2d(in_channels=32, out_channels=8, groups=1, kernel_size=1)
+            
+            self.conv1.bias.copy_(torch.rand_like(self.conv1.bias))
+            self.conv3.bias.copy_(torch.rand_like(self.conv3.bias))
+            self.convtranspose1.bias.copy_(torch.rand_like(self.convtranspose1.bias))
+            self.convtranspose3.bias.copy_(torch.rand_like(self.convtranspose3.bias))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.convtranspose1(x)
+        x = self.convtranspose2(x)
+        x = self.convtranspose3(x)
+        return x
+
+model = MyModel().cuda()
+dump_torch_to_onnx(model=model, onnx_export_file='model.onnx', input_shape=[1, 8, 96, 96])
+graph = load_onnx_graph(onnx_import_file='model.onnx')
+
+inputs   = [torch.rand(size=[1, 8, 96, 96]) for _ in range(32)]
+executor = TorchExecutor(graph=graph)
+b_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+b_outputs = torch.cat(b_outputs)
+
+from ppq.quantization.optim import LayerwiseEqualizationPass
+LayerwiseEqualizationPass(iterations=10, including_bias=True, including_act=True).optimize(
+    graph=graph, dataloader=inputs, executor=executor, collate_fn=lambda x: x.cuda())
+p_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+p_outputs = torch.cat(p_outputs)
+from ppq.quantization.measure import torch_snr_error
+assert torch_snr_error(b_outputs, p_outputs).item() < 1e-7
+
+
+class MyModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        with torch.no_grad():
+            self.conv1 = torch.nn.Conv3d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+            self.conv2 = torch.nn.Conv3d(in_channels=32, out_channels=32, groups=16, kernel_size=3, stride=1, padding=1, bias=False)
+            self.conv3 = torch.nn.Conv3d(in_channels=32, out_channels=8, groups=8, kernel_size=5, stride=1, padding=2)
+            self.conv4 = torch.nn.Conv3d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+
+            self.conv1.bias.copy_(torch.rand_like(self.conv1.bias))
+            self.conv3.bias.copy_(torch.rand_like(self.conv3.bias))
+            self.conv4.bias.copy_(torch.rand_like(self.conv4.bias))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.conv4(x)
+        return x
+
+model = MyModel().cuda()
+dump_torch_to_onnx(model=model, onnx_export_file='model.onnx', input_shape=[1, 8, 16, 96, 96])
+graph = load_onnx_graph(onnx_import_file='model.onnx')
+
+inputs   = [torch.rand(size=[1, 8, 16, 96, 96]) for _ in range(32)]
+executor = TorchExecutor(graph=graph)
+b_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+b_outputs = torch.cat(b_outputs)
+
+from ppq.quantization.optim import LayerwiseEqualizationPass
+LayerwiseEqualizationPass(iterations=10, including_bias=True, including_act=True).optimize(
+    graph=graph, dataloader=inputs, executor=executor, collate_fn=lambda x: x.cuda())
+p_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+p_outputs = torch.cat(p_outputs)
+from ppq.quantization.measure import torch_snr_error
+assert torch_snr_error(b_outputs, p_outputs).item() < 1e-7
+
+
+class MyModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        with torch.no_grad():
+            self.conv1 = torch.nn.Conv1d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+            self.conv2 = torch.nn.Conv1d(in_channels=32, out_channels=32, groups=16, kernel_size=3, stride=1, padding=1, bias=False)
+            self.conv3 = torch.nn.Conv1d(in_channels=32, out_channels=8, groups=8, kernel_size=5, stride=1, padding=2)
+            self.conv4 = torch.nn.Conv1d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+            
+            self.conv1.bias.copy_(torch.rand_like(self.conv1.bias))
+            self.conv3.bias.copy_(torch.rand_like(self.conv3.bias))
+            self.conv4.bias.copy_(torch.rand_like(self.conv4.bias))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.conv4(x)
+        return x
+
+model = MyModel().cuda()
+dump_torch_to_onnx(model=model, onnx_export_file='model.onnx', input_shape=[1, 8, 96])
+graph = load_onnx_graph(onnx_import_file='model.onnx')
+
+inputs   = [torch.rand(size=[1, 8, 96]) for _ in range(32)]
+executor = TorchExecutor(graph=graph)
+b_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+b_outputs = torch.cat(b_outputs)
+
+from ppq.quantization.optim import LayerwiseEqualizationPass
+LayerwiseEqualizationPass(iterations=10, including_bias=True, including_act=True).optimize(
+    graph=graph, dataloader=inputs, executor=executor, collate_fn=lambda x: x.cuda())
+p_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+p_outputs = torch.cat(p_outputs)
+from ppq.quantization.measure import torch_snr_error
+assert torch_snr_error(b_outputs, p_outputs).item() < 1e-7
+
+
+class MyModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        with torch.no_grad():
+            self.conv1 = torch.nn.ConvTranspose1d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+            self.conv2 = torch.nn.ConvTranspose1d(in_channels=32, out_channels=32, groups=16, kernel_size=3, stride=1, padding=1, bias=False)
+            self.conv3 = torch.nn.ConvTranspose1d(in_channels=32, out_channels=8, groups=8, kernel_size=5, stride=1, padding=2)
+            self.conv4 = torch.nn.ConvTranspose1d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+
+            self.conv1.bias.copy_(torch.rand_like(self.conv1.bias))
+            self.conv3.bias.copy_(torch.rand_like(self.conv3.bias))
+            self.conv4.bias.copy_(torch.rand_like(self.conv4.bias))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.conv4(x)
+        return x
+
+model = MyModel().cuda()
+dump_torch_to_onnx(model=model, onnx_export_file='model.onnx', input_shape=[1, 8, 96])
+graph = load_onnx_graph(onnx_import_file='model.onnx')
+
+inputs   = [torch.rand(size=[1, 8, 96]) for _ in range(32)]
+executor = TorchExecutor(graph=graph)
+b_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+b_outputs = torch.cat(b_outputs)
+
+from ppq.quantization.optim import LayerwiseEqualizationPass
+LayerwiseEqualizationPass(iterations=10, including_bias=True, including_act=True).optimize(
+    graph=graph, dataloader=inputs, executor=executor, collate_fn=lambda x: x.cuda())
+p_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+p_outputs = torch.cat(p_outputs)
+from ppq.quantization.measure import torch_snr_error
+assert torch_snr_error(b_outputs, p_outputs).item() < 1e-7
+
+class MyModel(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        with torch.no_grad():
+            self.conv1 = torch.nn.ConvTranspose3d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+            self.conv2 = torch.nn.ConvTranspose3d(in_channels=32, out_channels=32, groups=16, kernel_size=3, stride=1, padding=1, bias=False)
+            self.conv3 = torch.nn.ConvTranspose3d(in_channels=32, out_channels=8, groups=8, kernel_size=5, stride=1, padding=2)
+            self.conv4 = torch.nn.ConvTranspose3d(in_channels=8, out_channels=32, kernel_size=3, stride=2, padding=1)
+
+            self.conv1.bias.copy_(torch.rand_like(self.conv1.bias))
+            self.conv3.bias.copy_(torch.rand_like(self.conv3.bias))
+            self.conv4.bias.copy_(torch.rand_like(self.conv4.bias))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.conv4(x)
+        return x
+
+model = MyModel().cuda()
+dump_torch_to_onnx(model=model, onnx_export_file='model.onnx', input_shape=[1, 8, 8, 8, 8])
+graph = load_onnx_graph(onnx_import_file='model.onnx')
+
+inputs   = [torch.rand(size=[1, 8, 8, 8, 8]) for _ in range(32)]
+executor = TorchExecutor(graph=graph)
+b_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+b_outputs = torch.cat(b_outputs)
+
+from ppq.quantization.optim import LayerwiseEqualizationPass
+LayerwiseEqualizationPass(iterations=10, including_bias=True, including_act=True).optimize(
+    graph=graph, dataloader=inputs, executor=executor, collate_fn=lambda x: x.cuda())
+p_outputs = [executor.forward(inputs=t.cuda())[0].unsqueeze(0) for t in inputs]
+p_outputs = torch.cat(p_outputs)
+from ppq.quantization.measure import torch_snr_error
+assert torch_snr_error(b_outputs, p_outputs).item() < 1e-7


### PR DESCRIPTION
* 为dump_torch_to_onnx函数添加了默认参数
* EXPORT_OVERLAPPED_CONFIG 现在是过时参数，你将使用TQC上的QuantizationVisiblity属性来进行导出控制。该属性有三个可选项：强制导出、TQC激活时导出、不导出。
* 修改了 exporter 逻辑以适配新的QuantizationVisiblity属性
* 修改了onnx qdq的导出逻辑，现在将尽可能消除非对称量化中的激活函数。
* 修改了 graphwise analyser 的逻辑，现在允许分析多输出算子的误差
* 修改了 layerwise equalization 的逻辑，现在允许 include act，支持conv1d, conv2d conv3d, convtranpose1d, convtranspose2d, convtranspose3d, gemm, matmul
* 修复了 passive parameter pass 中的 pad 量化错误
* 修复了 quant alignment pass 中 pooling 算子的对齐错误
* 修复了 核心量化函数在启动 cuda kernel 的情况下无法处理 cpu tensor 的问题
* 修改 openvino 量化策略，负数部分现在可以取到-128(曾经是-127)
* 给 dsp quantizer 添加了一个新的量化类型