### PR TITLE
update onnx requirements support for save_model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-onnx >= 1.8.1
+onnx >= 1.9.0
 protobuf
 torch >= 1.6.0
 tqdm


### PR DESCRIPTION
when use onnx.save_model with arguments size_threshold, onnx <= 1.8.1 could not handle.