### PR TITLE
修正了一个 resize_forward 可能发生的错误

### DIFF
--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -1362,7 +1362,7 @@ def Resize_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBackendC
     # Not used roi
     # roi  = input_value[1] if len(input_value) > 1 else None
     scale_factor = values[2].cpu() if len(values) > 2 else None
-    size = values[-1].cpu().tolist() if len(values) == 4 else None
+    size = values[-1].cpu().tolist() if (len(values) == 4 and values[-1] is not None) else None
     mode = op.attributes.get('mode', 'nearest')
     if mode == 'cubic':
         mode = 'bicubic'


### PR DESCRIPTION
当resize算子恰好有4个输入且第四个输入为空时，将可能引发错误。这个补丁修复了上述情况。