### PR TITLE
fix align_to_large bug

### DIFF
--- a/ppq/quantization/optim/refine.py
+++ b/ppq/quantization/optim/refine.py
@@ -468,7 +468,7 @@ class QuantAlignmentPass(QuantizationOptimizationPass):
 
         device = master_config.scale.device
         master_config._dominator = master_config
-        master_config.state  = QuantizationStates.ACTIVATED
+        master_config.state  = QuantizationStates.PASSIVE
         master_config.scale  = torch.tensor(scale, dtype=torch.float32, device=device)
         master_config.offset = torch.tensor(offset, dtype=torch.float32, device=device)
 


### PR DESCRIPTION
修改主定点状态为QuantizationStates.PASSIVE，避免relu - add多分支量化参数导出时，量化参数的错误修改