### PR TITLE
Fix bug of onnx export

### DIFF
--- a/ppq/parser/onnx_exporter.py
+++ b/ppq/parser/onnx_exporter.py
@@ -214,7 +214,9 @@ class OnnxExporter(GraphExporter):
             if isinstance(value, DataType):
                 attributes[key] = value.value
             if isinstance(value, torch.Tensor):
-                attributes[key] = convert_any_to_numpy(value)
+                if value.numel() == 0: attributes[key] = None
+                elif value.numel() == 1: attributes[key] = value.item()
+                else: attributes[key] = convert_any_to_numpy(value)
 
         if PPQ_CONFIG.EXPORT_PPQ_INTERNAL_INFO:
             attributes['platform'] = operation.platform.name


### PR DESCRIPTION
当torch.tensor中仅包含一个元素时，由此生成的np.ndarray是0维的。
进而导致onnx导出错误。