### PR TITLE
修正了一个反卷积与Batchnorm进行合并时可能遇到的问题

### DIFF
--- a/ppq/IR/morph.py
+++ b/ppq/IR/morph.py
@@ -576,9 +576,9 @@ class GraphMerger(GraphCommandProcessor):
 
                 scale = alpha / torch.sqrt(var + epsilon)
                 group = computing_op.attributes.get('group', 1)
-                scale = scale.reshape([group, 1, -1, 1, 1])
-                w = w.reshape([group, -1, w.shape[1], w.shape[2], w.shape[3]]) * scale
-                w = w.reshape([w.shape[0] * w.shape[1], w.shape[2], w.shape[3], w.shape[4]])
+                scale = scale.reshape([group, 1, -1] + [1] * (w.ndim - 2))
+                w = w.reshape([group, -1] + list(w.shape[1:])) * scale
+                w = w.reshape([w.shape[0] * w.shape[1]] + list(w.shape[2:]))
                 b = alpha * (b - mean) / torch.sqrt(var + epsilon) + beta
             else:
                 raise TypeError(


### PR DESCRIPTION
* 现在反卷积与Batchnorm的合并支持1d, 2d, 3d卷积，过去只支持2d.