### PR TITLE
Use torch.amax in ReduceMax forward to support multiplie dim

### DIFF
--- a/ppq/executor/op/torch/default.py
+++ b/ppq/executor/op/torch/default.py
@@ -1619,7 +1619,7 @@ def ReduceMax_forward(op: Operation, values: List[torch.Tensor], ctx: TorchBacke
             if keepdim:
                 output = output.reshape([1] * input_value.dim())
         else:
-            output, _ = torch.max(input_value, dim=dim[0], keepdim=keepdim)
+            output = torch.amax(input_value, dim=dim, keepdim=keepdim)
     return output
 
 


### PR DESCRIPTION
# Motivation
- We can use `torch.amax` in ReduceMax forward to support multiplie dim.
- The detail of `torch.amax` can be found at: https://pytorch.org/docs/stable/generated/torch.amax.html#torch-amax
> The difference between max/min and amax/amin is:
> - amax/amin supports reducing on multiple dimensions,
> - amax/amin does not return indices,
> - amax/amin evenly distributes gradient between equal values, while max(dim)/min(dim) propagates gradient only to a single index in the source tensor.

# Modification
- `ppq/executor/op/torch/default.py`
  - Use torch.amax in ReduceMax forward to support multiplie dim